### PR TITLE
Add support for filtering release notes based on multiple keywords

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -3,7 +3,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
-async def get_paragraphs(db: AsyncSession, release_note_id: int, keyword: str):
+async def get_paragraphs(db: AsyncSession, release_note_id: str, keywords: list[str]):
     query = text("""
         SELECT section_id, metadata, raw_text,
                to_tsvector('english', raw_text) @@ to_tsquery('english', :keyword) AS relevant
@@ -11,7 +11,7 @@ async def get_paragraphs(db: AsyncSession, release_note_id: int, keyword: str):
         WHERE release_note_id = :release_note_id
     """)
 
-    result = await db.execute(query, {"release_note_id": release_note_id, "keyword": keyword})
+    result = await db.execute(query, {"release_note_id": release_note_id, "keyword": '|'.join(keywords)})
     rows = result.fetchall()
 
     paragraphs = [

--- a/app/crud.py
+++ b/app/crud.py
@@ -15,7 +15,7 @@ async def get_paragraphs(db: AsyncSession, release_note_id: str, keywords: list[
     rows = result.fetchall()
 
     paragraphs = [
-        {"section_id": row.section_id, "raw_text": row.raw_text, "relevant": row.relevant, "metadata": row.metadata}
+        {"section_id": row.section_id, "raw_text": row.raw_text, "metadata": row.metadata}
         for row in rows
     ]
     return paragraphs

--- a/app/crud.py
+++ b/app/crud.py
@@ -17,11 +17,8 @@ async def get_paragraphs(db: AsyncSession, release_note_id: str, keywords: list[
         ;
     """)
 
-    result = await db.execute(query, {"release_note_id": release_note_id, "keyword": '|'.join(keywords)})
+    result = await db.execute(query, {"release_note_id": release_note_id, "keyword": "|".join(keywords)})
     rows = result.fetchall()
 
-    paragraphs = [
-        {"section_id": row.section_id, "raw_text": row.raw_text, "metadata": row.metadata}
-        for row in rows
-    ]
+    paragraphs = [{"section_id": row.section_id, "raw_text": row.raw_text, "metadata": row.metadata} for row in rows]
     return paragraphs

--- a/app/crud.py
+++ b/app/crud.py
@@ -5,10 +5,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 async def get_paragraphs(db: AsyncSession, release_note_id: str, keywords: list[str]):
     query = text("""
-        SELECT section_id, metadata, raw_text,
-               to_tsvector('english', raw_text) @@ to_tsquery('english', :keyword) AS relevant
-        FROM paragraphs
-        WHERE release_note_id = :release_note_id
+        SELECT
+            section_id,
+            metadata,
+            raw_text
+        FROM
+            paragraphs
+        WHERE
+            to_tsvector('english', raw_text) @@ to_tsquery('english', :keyword)
+            AND release_note_id = :release_note_id
+        ;
     """)
 
     result = await db.execute(query, {"release_note_id": release_note_id, "keyword": '|'.join(keywords)})

--- a/app/models.py
+++ b/app/models.py
@@ -10,4 +10,3 @@ class TaggedParagraph(BaseModel):
     title: str = Field(..., description="The paragraph title")
     text: str = Field(..., description="The paragraph text")
     tag: str = Field(..., description="The paragraph htmltag")
-    relevant: bool = Field(..., description="Whether the paragraph is relevant to the search query")

--- a/app/v1/released/endpoints.py
+++ b/app/v1/released/endpoints.py
@@ -17,10 +17,10 @@ async def get_relevant(
     keywords: Optional[list[str]] = Query(None, description="List of keywords to search for"),
     db: AsyncSession = Depends(get_db),
 ):
-    release_note_id = f"release_RHEL_{major}.{minor}"
 
     # This is obviously not enough
     keyword = keywords[0] if keywords else "security"
+    release_note_id = f"RHEL_{major}.{minor}"
 
     try:
         paragraphs = await get_paragraphs(db, release_note_id, keyword)

--- a/app/v1/released/endpoints.py
+++ b/app/v1/released/endpoints.py
@@ -17,10 +17,8 @@ async def get_relevant(
     keywords: Optional[list[str]] = Query(None, description="List of keywords to search for"),
     db: AsyncSession = Depends(get_db),
 ):
-
-    # This is obviously not enough
-    keyword = keywords[0] if keywords else "security"
     release_note_id = f"RHEL_{major}.{minor}"
+    keyword = keywords or ["security"]
 
     try:
         paragraphs = await get_paragraphs(db, release_note_id, keyword)

--- a/app/v1/released/endpoints.py
+++ b/app/v1/released/endpoints.py
@@ -27,7 +27,9 @@ async def get_relevant(
 
     return [
         TaggedParagraph(
-            title=paragraph["section_id"], text=paragraph["raw_text"], tag="h2",
+            title=paragraph["section_id"],
+            text=paragraph["raw_text"],
+            tag="h2",
         )
         for paragraph in paragraphs
     ]

--- a/app/v1/released/endpoints.py
+++ b/app/v1/released/endpoints.py
@@ -27,7 +27,7 @@ async def get_relevant(
 
     return [
         TaggedParagraph(
-            title=paragraph["section_id"], text=paragraph["raw_text"], tag="h2", relevant=paragraph["relevant"]
+            title=paragraph["section_id"], text=paragraph["raw_text"], tag="h2",
         )
         for paragraph in paragraphs
     ]


### PR DESCRIPTION
Only return results matching the supplied keywords.

```
python
def send_request():
    # Release Notes
    # GET http://localhost:8081/api/digital-roadmap/v1/release-notes/get-relevant-notes/

    try:
        response = requests.get(
            url="http://localhost:8081/api/digital-roadmap/v1/release-notes/get-relevant-notes/",
            params={
                "keywords": "security,dns,selinux",
                "major": "9",
                "minor": "5",
            },
        )
        print('Response HTTP Status Code: {status_code}'.format(
            status_code=response.status_code))
        print('Response HTTP Response Body: {content}'.format(
            content=response.content))
    except requests.exceptions.RequestException:
        print('HTTP Request failed')
```