### PR TITLE
Make it easier to run the database

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Run PostgreSQL
+        run: make run-db
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run PostgreSQL
-        run: make run-db
+        run: make start-db
 
       - name: Install dependencies
         run: |

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ifeq ($(OS), Darwin)
 	CONTAINER_RUNTIMES = docker podman
 endif
 
-CONTAINER_RUNTIME ?= $(shell type -P $(CONTAINER_RUNTIMES) | head -n 1)
+CONTAINER_RUNTIME ?= $(shell type -P $(CONTAINER_RUNTIMES) 2>&1 | head -n 1)
 
 
 default: install

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,13 @@ install-dev: venv
 	$(PIP) install -r requirements/requirements-dev-$(PYTHON_VERSION).txt
 
 .PHONY: run-db
-run-db:
+run-db: stop-db
+	$(CONTAINER_RUNTIME) run --rm -d -p $(DB_PORT):5432 --name digital-roadmap-data $(DB_IMAGE)
+
+.PHONY: stop-db
+stop-db:
 	@$(CONTAINER_RUNTIME) stop digital-roadmap-data > /dev/null 2>&1 || true
 	@sleep 0.1
-	$(CONTAINER_RUNTIME) run --rm -d -p $(DB_PORT):5432 --name digital-roadmap-data $(DB_IMAGE)
 
 .PHONY: run
 run:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ export PIP_DISABLE_PIP_VERSION_CHECK = 1
 DB_IMAGE ?= quay.io/samdoran/digital-roadmap-data
 DB_PORT ?= 5432
 
+# Set the shell because otherwise this defaults to /bin/sh,
+# which is dash on Ubuntu. The type builtin for dash does not accept flags.
+SHELL = /bin/bash
+
 # Determine container runtime, preferring Docker on macOS
 OS = $(shell uname)
 CONTAINER_RUNTIMES = podman docker

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Create a virtual environment, install the requirements, and run the server.
 
 ```shell
 make install
-make run
+make run-db run
 ```
 
 This runs a server using the default virtual environment. Documentation can be found at  `http://127.0.0.1:8081/docs`.
@@ -26,7 +26,7 @@ Install the developer tools and run the server.
 
 ```shell
 make install-dev
-make run
+make run-db run
 ```
 
 Alternatively you may create your own virtual environment, install the requirements, and run the server manually.
@@ -36,6 +36,16 @@ pip install -r requirements/requirements-dev-{Python version}.txt
 fastapi run app/main.py --reload --host 127.0.0.1 --port 8081
 ```
 
+The database runs in a container and contains data already. To specify a different container image, set `DB_IMAGE`.
+
+```shell
+export DB_IMAGE=digital-roadmap:latest
+make run-db
+```
+
+To restart the database container, run `make run-db`.
+
+To stop the database, run `make stop-db`.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Create a virtual environment, install the requirements, and run the server.
 
 ```shell
 make install
-make run-db run
+make start-db run
 ```
 
 This runs a server using the default virtual environment. Documentation can be found at  `http://127.0.0.1:8081/docs`.
@@ -26,7 +26,7 @@ Install the developer tools and run the server.
 
 ```shell
 make install-dev
-make run-db run
+make start-db run
 ```
 
 Alternatively you may create your own virtual environment, install the requirements, and run the server manually.
@@ -40,10 +40,10 @@ The database runs in a container and contains data already. To specify a differe
 
 ```shell
 export DB_IMAGE=digital-roadmap:latest
-make run-db
+make start-db
 ```
 
-To restart the database container, run `make run-db`.
+To restart the database container, run `make start-db`.
 
 To stop the database, run `make stop-db`.
 

--- a/app/config.py
+++ b/app/config.py
@@ -4,7 +4,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 DB_NAME = os.getenv("DB_NAME", "digital_roadmap")
 DB_USER = os.getenv("DB_USER", "postgres")
-DB_PASSWORD = os.getenv("DB_PASSWORD", "password")
+DB_PASSWORD = os.getenv("DB_PASSWORD", "postgres")
 DB_HOST = os.getenv("DB_HOST", "localhost")
 DB_PORT = os.getenv("DB_PORT", 5432)
 SQLALCHEMY_DATABASE_URI = f"postgresql+psycopg://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"


### PR DESCRIPTION
Pull a pre-built database container.
Add variables for database image and port for easy overrides.
Detect container runtime with different precedence based on OS.