### PR TITLE
Update setup docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
-# Variables
+PROJECT_DIR=$(shell pwd)
+
 VENV_DIR=.venvs/digital_roadmap
-PYTHON=$(VENV_DIR)/bin/python
-PIP=$(VENV_DIR)/bin/python -m pip
+PYTHON ?= $(shell which python || which python3)
+VENV_PYTHON=$(VENV_DIR)/bin/python
+PYTHON_VERSION = $(shell $(VENV_PYTHON) -V | cut -d ' ' -f 2 | cut -d '.' -f 1,2)
+PIP=$(VENV_PYTHON) -m pip
+
+PYTEST=$(VENV_DIR)/bin/pytest
 RUFF=$(VENV_DIR)/bin/ruff
 PRE_COMMIT=$(VENV_DIR)/bin/pre-commit
-PYTEST=$(VENV_DIR)/bin/pytest
-PROJECT_DIR=$(shell pwd)
-PYTHON_VERSION = $(shell python -V | cut -d ' ' -f 2 | cut -d '.' -f 1,2)
+
 export PIP_DISABLE_PIP_VERSION_CHECK = 1
 
 DB_IMAGE ?= quay.io/samdoran/digital-roadmap-data
@@ -30,11 +33,11 @@ default: install
 
 .PHONY: venv
 venv:
-	python3 -m venv --clear $(VENV_DIR)
+	$(PYTHON) -m venv --clear $(VENV_DIR)
 
 .PHONY: install
 install: venv
-	$(PIP) install -r requirements/requirements-$(PYTHON_VERSION).txt
+	$(PIP) install --no-cache -r requirements/requirements-$(PYTHON_VERSION).txt
 
 .PHONY: install-dev
 install-dev: venv

--- a/README.md
+++ b/README.md
@@ -5,8 +5,41 @@ API server providing access to Red Hat Enterprise Linux roadmap information.
 
 ## Prerequisites
 
-Python 3.12 or later.
-A container runtime such as `docker` or `podman`.
+- Python 3.12 or later.
+- A container runtime such as `docker` or `podman`.
+
+### Prerequisites for `psycopg` ###
+
+In order to create a [local installation] of `psycopg`, the the following packages and configuration are required.
+
+#### Linux ####
+
+RHEL
+
+```shell
+PYTHON_VERSION=3.12
+yum -y install "python${PYTHON_VERSION}-devel" gcc libpq-devel
+```
+
+Debian
+
+```shell
+PYTHON_VERSION=3.12
+apt install -y \
+    python3-pip \
+    "python${PYTHON_VERSION}-dev" \
+    "python${PYTHON_VERSION}-venv" \
+    gcc libpq-dev
+```
+
+#### macOS ####
+
+`libpq` is required and `pg_config` must be in the `PATH`. These directions assume `zsh`, but you can run `brew info libpq` for instructions specific to your shell.
+
+```shell
+brew install libpq
+echo 'export PATH="/opt/homebrew/opt/libpq/bin:$PATH"' >> ~/.zshrc
+```
 
 
 ## Setup Instructions
@@ -82,3 +115,6 @@ make freeze
 ```
 
 Commit the changes.
+
+
+[local installation]: https://www.psycopg.org/psycopg3/docs/basic/install.html#local-installation


### PR DESCRIPTION
Include necessary packages and configuration for Linux and macOS.

Make environment setup tasks more resilient by finding the system Python once checking for both `python` and `python3`.