### PR TITLE
Correctly install psycopg

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9-minimal:latest
+FROM registry.access.redhat.com/ubi9-minimal:latest AS builder
 
 LABEL com.redhat.component=rhel-roadmap-api
 LABEL description="Red Hat Enterprise Linux Roadmap API"
@@ -18,17 +18,33 @@ ENV PYTHON="${VENV}/bin/python"
 ENV PATH="${VENV}/bin:$PATH"
 ENV PYTHON_VERSION="3.12"
 
-COPY LICENSE /licenses/Apache-2.0.txt
-
-RUN microdnf install -y \
-    libpq \
+RUN microdnf install -y --nodocs \
+    gcc \
+    libpq-devel \
     "python${PYTHON_VERSION}" \
+    "python${PYTHON_VERSION}-devel" \
     && rm -rf /var/cache/yum/*
 
 COPY "requirements/requirements-${PYTHON_VERSION}.txt" /usr/share/container-setup/requirements.txt
 RUN "python${PYTHON_VERSION}" -m venv "$VENV" \
     && "$PYTHON" -m pip install --no-cache-dir --upgrade pip setuptools \
     && "$PYTHON" -m pip install --no-cache-dir --requirement /usr/share/container-setup/requirements.txt
+
+
+FROM registry.access.redhat.com/ubi9-minimal:latest AS final
+
+ENV VENV=/opt/venvs/rhel_roadmap
+ENV PYTHON="${VENV}/bin/python"
+ENV PATH="${VENV}/bin:$PATH"
+ENV PYTHON_VERSION="3.12"
+
+COPY LICENSE /licenses/Apache-2.0.txt
+COPY --from=builder "${VENV}" "${VENV}"
+
+RUN microdnf install -y --nodocs \
+    libpq \
+    "python${PYTHON_VERSION}" \
+    && rm -rf /var/cache/yum/*
 
 COPY app/ /srv/rhel_roadmap/app/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 mdurl==0.1.2
 psycopg==3.2.4
+psycopg-c==3.2.4
 pydantic==2.10.5
 pydantic_core==2.27.2
 Pygments==2.19.1

--- a/requirements/requirements-3.12.txt
+++ b/requirements/requirements-3.12.txt
@@ -17,6 +17,7 @@ markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 mdurl==0.1.2
 psycopg==3.2.4
+psycopg-c==3.2.4
 pydantic==2.10.5
 pydantic_core==2.27.2
 Pygments==2.19.1

--- a/requirements/requirements-3.13.txt
+++ b/requirements/requirements-3.13.txt
@@ -17,6 +17,7 @@ markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 mdurl==0.1.2
 psycopg==3.2.4
+psycopg-c==3.2.4
 pydantic==2.10.5
 pydantic_core==2.27.2
 Pygments==2.19.1

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,4 +1,4 @@
 fastapi[standard]
 greenlet
 sqlalchemy
-psycopg
+psycopg[c]


### PR DESCRIPTION
Perform a [local installation](https://www.psycopg.org/psycopg3/docs/basic/install.html#local-installation) of `psycopg`.

Use a multi-stage build to keep the final container image size down.

```
> docker image ls -f reference='digital-roadmap'
REPOSITORY        TAG       IMAGE ID       CREATED         SIZE
digital-roadmap   latest    1de2178c1830   4 minutes ago   266MB
```