### PR TITLE
Use module names instead of aliases for routes

### DIFF
--- a/src/roadmap/main.py
+++ b/src/roadmap/main.py
@@ -1,9 +1,7 @@
 from fastapi import APIRouter, FastAPI
 from prometheus_fastapi_instrumentator import Instrumentator
 
-from roadmap.v1.lifecycle import v1_router as lifecycle_v1_router
-from roadmap.v1.release_notes import v1_router as release_notes_v1_router
-from roadmap.v1.upcoming import v1_router as upcoming_v1_router
+import roadmap.v1
 
 # Initialize FastAPI app
 app = FastAPI()
@@ -13,13 +11,11 @@ instrumentor = Instrumentator()
 instrumentor.instrument(app, metric_namespace="digital_roadmap")
 instrumentor.expose(app)
 
-# Create a main API router with the /api prefix
-api_router = APIRouter()
+# Create a main API router with the base prefix
+api_router = APIRouter(prefix="/api/digital-roadmap", tags=["digital-roadmap"])
 
 # Include individual service routers under the main API router
-api_router.include_router(release_notes_v1_router, prefix="/v1/release-notes", tags=["release-notes"])
-api_router.include_router(upcoming_v1_router, prefix="/v1/upcoming-changes", tags=["upcoming-changes"])
-api_router.include_router(lifecycle_v1_router, prefix="/v1/lifecycle")
+api_router.include_router(roadmap.v1.router)
 
 
 @api_router.get("/v1/ping")
@@ -27,5 +23,5 @@ async def ping():
     return {"status": "pong"}
 
 
-# Include the main API router in the FastAPI app with the prefix
-app.include_router(api_router, prefix="/api/digital-roadmap", tags=["digital-roadmap"])
+# Include the main API router in the FastAPI app
+app.include_router(api_router)

--- a/src/roadmap/v1/__init__.py
+++ b/src/roadmap/v1/__init__.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+from . import lifecycle, release_notes, upcoming
+
+router = APIRouter(prefix="/v1")
+router.include_router(lifecycle.router)
+router.include_router(release_notes.router)
+router.include_router(upcoming.router)

--- a/src/roadmap/v1/lifecycle/__init__.py
+++ b/src/roadmap/v1/lifecycle/__init__.py
@@ -1,8 +1,7 @@
 from fastapi import APIRouter
 
-from .app_streams import v1_router as app_streams_v1_router
-from .systems import v1_router as systems_v1_router
+from . import app_streams, systems
 
-v1_router = APIRouter()
-v1_router.include_router(systems_v1_router)
-v1_router.include_router(app_streams_v1_router)
+router = APIRouter(prefix="/lifecycle")
+router.include_router(app_streams.router)
+router.include_router(systems.router)

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -6,14 +6,14 @@ from fastapi.responses import JSONResponse
 
 from roadmap.data import MODULE_DATA
 
-v1_router = APIRouter(
+router = APIRouter(
     prefix="/app-streams",
     tags=["lifecycle", "app streams"],
     responses={404: {"description": "Not found"}},
 )
 
 
-@v1_router.get("/")
+@router.get("/")
 async def get_app_streams(
     name: t.Annotated[str | None, Query(description="Module name")] = None,
 ):
@@ -28,14 +28,14 @@ async def get_app_streams(
     return {"data": [module for module in MODULE_DATA]}
 
 
-@v1_router.get("/{major_version}")
+@router.get("/{major_version}")
 async def get_major_version(
     major_version: t.Annotated[int, Path(description="Major RHEL version", gt=1, le=200)],
 ):
     return {"data": [module for module in MODULE_DATA if module.get("rhel_major_version", 0) == major_version]}
 
 
-@v1_router.get("/{major_version}/names")
+@router.get("/{major_version}/names")
 async def get_module_names(
     major_version: t.Annotated[int, Path(description="Major RHEL version", gt=1, le=200)],
 ) -> dict[str, list[str]]:
@@ -43,7 +43,7 @@ async def get_module_names(
     return {"names": sorted(item["module_name"] for item in data)}
 
 
-@v1_router.get("/{major_version}/{module_name}")
+@router.get("/{major_version}/{module_name}")
 async def get_module(
     major_version: t.Annotated[int, Path(description="Major RHEL version", gt=1, le=200)],
     module_name: t.Annotated[str, Path(description="Module name")],

--- a/src/roadmap/v1/lifecycle/systems.py
+++ b/src/roadmap/v1/lifecycle/systems.py
@@ -2,27 +2,27 @@ from fastapi import APIRouter, Path
 
 from roadmap.data.systems import OS_DATA_MOCKED
 
-v1_router = APIRouter(
+router = APIRouter(
     prefix="/systems",
     tags=["lifecycle", "systems"],
 )
 
 
-@v1_router.get("/")
+@router.get("/")
 async def get_systems():
     systems = get_systems_data()
 
     return sorted(systems, key=lambda d: (d["major"], d["minor"]))
 
 
-@v1_router.get("/{major}")
+@router.get("/{major}")
 async def get_systems_major(major: int = Path(..., description="Major version number")):
     systems = get_systems_data(major)
 
     return sorted(systems, key=lambda d: (d["major"], d["minor"]))
 
 
-@v1_router.get("/{major}/{minor}")
+@router.get("/{major}/{minor}")
 async def get_systems_major_minor(
     major: int = Path(..., description="Major version number"),
     minor: int = Path(..., description="Minor version number"),

--- a/src/roadmap/v1/release_notes.py
+++ b/src/roadmap/v1/release_notes.py
@@ -7,10 +7,10 @@ from roadmap.crud import get_paragraphs
 from roadmap.database import get_db
 from roadmap.models import TaggedParagraph
 
-v1_router = APIRouter()
+router = APIRouter(prefix="/release-notes", tags=["release notes"])
 
 
-@v1_router.get("/")
+@router.get("/")
 async def get_release_notes(
     major: int = Query(..., description="Major version number"),
     minor: int = Query(..., description="Minor version number"),

--- a/src/roadmap/v1/upcoming.py
+++ b/src/roadmap/v1/upcoming.py
@@ -2,10 +2,10 @@ from fastapi import APIRouter
 
 from roadmap.data import UPCOMING_DATA
 
-v1_router = APIRouter()
+router = APIRouter(prefix="/upcoming-changes", tags=["upcoming changes"])
 
 
-@v1_router.get("/")
+@router.get("/")
 async def get_upcoming():
     # TODO: Replace fixture data with data from database
     return UPCOMING_DATA


### PR DESCRIPTION
This makes things much more hierarchical and simplifies the imports at the main application level.