### PR TITLE
Streamline API paths and documentation

### DIFF
--- a/src/roadmap/main.py
+++ b/src/roadmap/main.py
@@ -30,11 +30,11 @@ app = FastAPI()
 
 # Add Prometheus metrics
 instrumentor = Instrumentator()
-instrumentor.instrument(app, metric_namespace="digital_roadmap")
-instrumentor.expose(app)
+instrumentor.instrument(app, metric_namespace="roadmap")
+instrumentor.expose(app, tags=["Status"])
 
 # Create a main API router with the base prefix
-api_router = APIRouter(prefix="/api/digital-roadmap", tags=["digital-roadmap"])
+api_router = APIRouter(prefix="/api/roadmap", tags=["Roadmap"])
 
 # Additional route to the OpenAPI JSON under the versioned path
 roadmap.v1.router.add_api_route("/openapi.json", app.openapi, include_in_schema=False)
@@ -43,7 +43,7 @@ roadmap.v1.router.add_api_route("/openapi.json", app.openapi, include_in_schema=
 api_router.include_router(roadmap.v1.router)
 
 
-@api_router.get("/v1/ping")
+@api_router.get("/v1/ping", tags=["Status"])
 async def ping():
     return {"status": "pong"}
 

--- a/src/roadmap/v1/lifecycle/__init__.py
+++ b/src/roadmap/v1/lifecycle/__init__.py
@@ -1,9 +1,9 @@
 from fastapi import APIRouter
 
 from . import app_streams
-from . import systems
+from . import rhel
 
 
-router = APIRouter(prefix="/lifecycle")
+router = APIRouter(prefix="/lifecycle", tags=["Lifecycle"])
 router.include_router(app_streams.router)
-router.include_router(systems.router)
+router.include_router(rhel.router)

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -10,7 +10,7 @@ from roadmap.data import MODULE_DATA
 
 router = APIRouter(
     prefix="/app-streams",
-    tags=["lifecycle", "app streams"],
+    tags=["App Streams"],
     responses={404: {"description": "Not found"}},
 )
 
@@ -20,10 +20,7 @@ async def get_app_streams(
     name: t.Annotated[str | None, Query(description="Module name")] = None,
 ):
     if name:
-        result = []
-        for module in MODULE_DATA:
-            if name.lower() in module["module_name"].lower():
-                result.append(module)
+        result = [module for module in MODULE_DATA if name.lower() in module["module_name"].lower()]
 
         return {"data": result}
 

--- a/src/roadmap/v1/lifecycle/rhel.py
+++ b/src/roadmap/v1/lifecycle/rhel.py
@@ -7,8 +7,8 @@ from roadmap.data.systems import OS_DATA_MOCKED
 
 
 router = APIRouter(
-    prefix="/systems",
-    tags=["lifecycle", "systems"],
+    prefix="/rhel",
+    tags=["RHEL"],
 )
 
 

--- a/src/roadmap/v1/release_notes.py
+++ b/src/roadmap/v1/release_notes.py
@@ -11,7 +11,7 @@ from roadmap.database import get_db
 from roadmap.models import TaggedParagraph
 
 
-router = APIRouter(prefix="/release-notes", tags=["release notes"])
+router = APIRouter(prefix="/release-notes", tags=["Release Notes"])
 
 
 @router.get("/")

--- a/src/roadmap/v1/upcoming.py
+++ b/src/roadmap/v1/upcoming.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter
 from roadmap.data import UPCOMING_DATA
 
 
-router = APIRouter(prefix="/upcoming-changes", tags=["upcoming changes"])
+router = APIRouter(prefix="/upcoming-changes", tags=["Upcoming Changes"])
 
 
 @router.get("/")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,5 @@
 def test_ping(client):
-    response = client.get("/api/digital-roadmap/v1/ping")
+    response = client.get("/api/roadmap/v1/ping")
 
     assert response.status_code == 200
     assert response.json() == {"status": "pong"}
@@ -9,7 +9,7 @@ def test_metrics(client):
     response = client.get("/metrics")
 
     assert response.status_code == 200
-    assert b"digital_roadmap_http_request" in response.read()
+    assert b"roadmap_http_request" in response.read()
 
 
 def test_openapi_docs_root(client):
@@ -20,7 +20,7 @@ def test_openapi_docs_root(client):
 
 
 def test_openapi_docs_v1(client):
-    response = client.get("/api/digital-roadmap/v1/openapi.json")
+    response = client.get("/api/roadmap/v1/openapi.json")
 
     assert response.status_code == 200
     assert "paths" in response.json()

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -3,4 +3,4 @@ import pytest
 
 @pytest.fixture(scope="session")
 def api_prefix():
-    return "/api/digital-roadmap/v1"
+    return "/api/roadmap/v1"

--- a/tests/v1/lifecycle/test_rhel.py
+++ b/tests/v1/lifecycle/test_rhel.py
@@ -51,6 +51,6 @@ import roadmap
     ),
 )
 def test_system_specified(client, api_prefix, source_data, path, response, monkeypatch):
-    monkeypatch.setattr(roadmap.v1.lifecycle.systems, "OS_DATA_MOCKED", source_data)
-    data = client.get(f"{api_prefix}/lifecycle/systems{path}")
+    monkeypatch.setattr(roadmap.v1.lifecycle.rhel, "OS_DATA_MOCKED", source_data)
+    data = client.get(f"{api_prefix}/lifecycle/rhel{path}")
     assert data.json() == sorted(response, key=itemgetter("major", "minor"), reverse=True)


### PR DESCRIPTION
- Change “digital-roadmap” to “roadmap”
- Change “systems” to “rhel”
- Update documentation tags for better grouping and presentation

Here are the new APIs:
```
[
  "/metrics",
  "/api/roadmap/v1/lifecycle/app-streams/",
  "/api/roadmap/v1/lifecycle/app-streams/{major_version}",
  "/api/roadmap/v1/lifecycle/app-streams/{major_version}/names",
  "/api/roadmap/v1/lifecycle/app-streams/{major_version}/{module_name}",
  "/api/roadmap/v1/lifecycle/rhel/",
  "/api/roadmap/v1/lifecycle/rhel/{major}",
  "/api/roadmap/v1/lifecycle/rhel/{major}/{minor}",
  "/api/roadmap/v1/release-notes/",
  "/api/roadmap/v1/upcoming-changes/",
  "/api/roadmap/v1/ping"
]
```