### PR TITLE
[RSPEED-580] Add relevant app stream API

### DIFF
--- a/src/roadmap/v1/__init__.py
+++ b/src/roadmap/v1/__init__.py
@@ -7,6 +7,7 @@ from . import upcoming
 
 router = APIRouter(prefix="/v1")
 router.include_router(lifecycle.router)
-router.include_router(release_notes.router)
-router.include_router(upcoming.router)
+router.include_router(lifecycle.app_streams.relevant)
 router.include_router(lifecycle.rhel.relevant)
+router.include_router(upcoming.router)
+router.include_router(release_notes.router)

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -2,9 +2,9 @@ import typing as t
 
 from fastapi import APIRouter
 from fastapi import Path
+from fastapi.exceptions import HTTPException
 from fastapi.param_functions import Query
 from fastapi.params import Depends
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from roadmap.data import MODULE_DATA
@@ -14,6 +14,11 @@ from roadmap.models import Meta
 class AppStreamsResponse(BaseModel):
     meta: Meta
     data: list[dict]
+
+
+class AppStreamsNamesResponse(BaseModel):
+    meta: Meta
+    data: list[str]
 
 
 router = APIRouter(
@@ -31,43 +36,50 @@ async def get_app_streams(
         result = [module for module in MODULE_DATA if name.lower() in module["module_name"].lower()]
 
         return {
-            "meta": {"total": 0, "count": 10},
+            "meta": {"total": len(result), "count": len(result)},
             "data": result,
         }
 
     return {
-        "meta": {"total": 0, "count": 10},
+        "meta": {"total": len(MODULE_DATA), "count": len(MODULE_DATA)},
         "data": [module for module in MODULE_DATA],
     }
 
 
-@router.get("/{major_version}")
+@router.get("/{major_version}", response_model=AppStreamsResponse)
 async def get_major_version(
     major_version: t.Annotated[int, Path(description="Major RHEL version", gt=1, le=200)],
 ):
-    return {"data": [module for module in MODULE_DATA if module.get("rhel_major_version", 0) == major_version]}
+    modules = [module for module in MODULE_DATA if module.get("rhel_major_version", 0) == major_version]
+    return {
+        "meta": {"total": len(modules), "count": len(modules)},
+        "data": modules,
+    }
 
 
-@router.get("/{major_version}/names")
+@router.get("/{major_version}/names", response_model=AppStreamsNamesResponse)
 async def get_module_names(
     major_version: t.Annotated[int, Path(description="Major RHEL version", gt=1, le=200)],
-) -> dict[str, list[str]]:
-    data = [module for module in MODULE_DATA if module.get("rhel_major_version", 0) == major_version]
-    return {"names": sorted(item["module_name"] for item in data)}
+):
+    modules = [module for module in MODULE_DATA if module.get("rhel_major_version", 0) == major_version]
+    return {
+        "meta": {"total": len(modules), "count": len(modules)},
+        "data": sorted(item["module_name"] for item in modules),
+    }
 
 
-@router.get("/{major_version}/{module_name}")
+@router.get("/{major_version}/{module_name}", response_model=AppStreamsResponse)
 async def get_module(
     major_version: t.Annotated[int, Path(description="Major RHEL version", gt=1, le=200)],
     module_name: t.Annotated[str, Path(description="Module name")],
 ):
     if data := [module for module in MODULE_DATA if module.get("rhel_major_version", 0) == major_version]:
         if modules := sorted(item for item in data if item.get("module_name") == module_name):
-            return {"data": modules}
+            return {"meta": {"total": len(modules), "count": len(modules)}, "data": modules}
 
-    return JSONResponse(
-        content={"message": "No modules matches query", "query": module_name},
+    raise HTTPException(
         status_code=404,
+        detail=f"No modules found with name '{module_name}'",
     )
 
 

--- a/tests/fixtures/inventory_response.json
+++ b/tests/fixtures/inventory_response.json
@@ -856,6 +856,9 @@
         "installed_products": [
           {
             "id": "479"
+          },
+          {
+            "id": "204"
           }
         ]
       },
@@ -965,6 +968,9 @@
         "installed_products": [
           {
             "id": "479"
+          },
+          {
+            "id": "241"
           }
         ]
       },

--- a/tests/v1/lifecycle/test_app_streams.py
+++ b/tests/v1/lifecycle/test_app_streams.py
@@ -53,3 +53,11 @@ def test_get_app_stream_module_info_not_found(api_prefix, client):
 
     assert result.status_code == 404
     assert "no modules" in detail.lower()
+
+
+def test_get_relevant_app_stream(api_prefix, client):
+    result = client.get(f"{api_prefix}/relevant/lifecycle/app-streams/")
+    data = result.json().get("data", "")
+
+    assert result.status_code == 200
+    assert len(data) > 0

--- a/tests/v1/lifecycle/test_app_streams.py
+++ b/tests/v1/lifecycle/test_app_streams.py
@@ -31,7 +31,7 @@ def test_get_app_streams_by_name(api_prefix, client):
 @pytest.mark.parametrize("version", (8, 9))
 def test_get_app_stream_names(api_prefix, client, version):
     result = client.get(f"{api_prefix}/lifecycle/app-streams/{version}/names")
-    names = result.json().get("names", [])
+    names = result.json().get("data", [])
 
     assert result.status_code == 200
     assert len(names) > 0
@@ -49,7 +49,7 @@ def test_get_app_stream_module_info(api_prefix, client):
 
 def test_get_app_stream_module_info_not_found(api_prefix, client):
     result = client.get(f"{api_prefix}/lifecycle/app-streams/8/NOPE")
-    message = result.json().get("message", "")
+    detail = result.json().get("detail", "")
 
     assert result.status_code == 404
-    assert "no modules" in message.lower()
+    assert "no modules" in detail.lower()


### PR DESCRIPTION
This is returning the same data as `/api/roadmap/v1/lifecycle/app-streams/` for now so that UI work can continue.

I added response models for the app streams responses to solidify things a bit.

#### Test the new API ####


```
http localhost:8081/api/roadmap/v1/relevant/lifecycle/app-streams/
```
