### PR TITLE
Change MIN_REPLICAS type from number to string

### DIFF
--- a/deploy/config.yml
+++ b/deploy/config.yml
@@ -96,7 +96,7 @@ parameters:
 
   - name: MIN_REPLICAS
     description: Replica count for backend service
-    value: 3
+    value: "3"
 
   - name: APP_NAME
     required: true


### PR DESCRIPTION
I tried to add the backend deployment to AppSRE but the pipeline ended with an error:

> `[2025-03-14 09:06:06] [ERROR] [DRY-RUN] [saasherder.py:_process_template:962] - [saas-digital-roadmap/roadmap-backend] https://github.com/RedHatInsights/digital-roadmap-backend/blob/internal/deploy/config.yml: error processing template: [None]: error: failed to read input object (not a Template?): unable to decode "STDIN": json: cannot unmarshal number into Go struct field Parameter.parameters.value of type string`

https://ci.int.devshift.net/job/service-app-interface-gl-pr-check/487006/artifact/temp/reports/index.html

After double checking with other templates looks like the parameter passed down to `minReplicas` usually is a string. (e.g. [https://github.com/RedHatInsights/insights-host-inventory/blob/master/deploy/clowdapp.yml#L1657](https://github.com/RedHatInsights/insights-host-inventory/blob/master/deploy/clowdapp.yml#L1657))