### PR TITLE
Set umask when creating home directory

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -47,7 +47,7 @@ RUN microdnf install -y --nodocs \
     "python${PYTHON_VERSION}" \
     && rm -rf /var/cache/yum/*
 
-RUN useradd --system --create-home --home-dir /srv/roady roady
+RUN useradd --key HOME_MODE=0755 --system --create-home --home-dir /srv/roady roady
 
 COPY /src/roadmap/ /srv/roady/roadmap/
 


### PR DESCRIPTION
The default is 0700 which means the application code is only readable by the UID that owns the home directory. OpenShift runs with a random UID so it needs to be world readable.