### PR TITLE
[RSPEED-828] Normalize app stream names

### DIFF
--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -68,6 +68,18 @@ class AppStreamCount(BaseModel):
     stream: str
     impl: AppStreamImplementation
     rolling: bool = False
+    normalized_name: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_stream_name(cls, data: t.Any) -> t.Any:
+        if "postgresql" in data["name"].lower():
+            data["name"] = "PostgreSQL"
+
+        if data["stream"]:
+            logger.debug(f"{data['name']} {data['stream']}")
+
+        return data
 
 
 class AppStream(BaseModel):


### PR DESCRIPTION
This feels like the wrong place to be doing this. It seems like we should be able to fetch the app stream names somehow instead of having to reconstruct them.

I think the challeng may be in needing to get the app stream name from the dnf module name.