### PR TITLE
Use psycopg (version 3) for database connection

### DIFF
--- a/requirements/requirements-replication-3.12.txt
+++ b/requirements/requirements-replication-3.12.txt
@@ -1,6 +1,5 @@
 app-common-python==0.2.7
 psycopg==3.2.6
 psycopg-c==3.2.6
-psycopg2==2.9.10
 SQLAlchemy==2.0.40
 typing_extensions==4.13.0

--- a/requirements/requirements-replication-3.13.txt
+++ b/requirements/requirements-replication-3.13.txt
@@ -1,6 +1,5 @@
 app-common-python==0.2.7
 psycopg==3.2.6
 psycopg-c==3.2.6
-psycopg2==2.9.10
 SQLAlchemy==2.0.40
 typing_extensions==4.13.0

--- a/requirements/requirements-replication.in
+++ b/requirements/requirements-replication.in
@@ -1,4 +1,3 @@
 app-common-python
 psycopg[c]
-psycopg2
 sqlalchemy

--- a/scripts/replication.py
+++ b/scripts/replication.py
@@ -71,7 +71,7 @@ def _init_config():
         if cfg.database.rdsCa:
             db_ssl_cert = cfg.rds_ca()
         db_ssl_mode = os.getenv("DB_SSL_MODE", "")
-        db_uri = f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
+        db_uri = f"postgresql:psycopg//{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
         if db_ssl_mode == SSL_VERIFY_FULL:
             db_uri += f"?sslmode={db_ssl_mode}&sslrootcert={db_ssl_cert}"
     return db_uri


### PR DESCRIPTION
Remove psycopg2 from requirements.
Change database URI so that the DBAPI is explicitly set to psycopg.