### PR TITLE
Set Sentry environment

### DIFF
--- a/deploy/config.yml
+++ b/deploy/config.yml
@@ -76,6 +76,9 @@ objects:
                     name: sentry
                     key: dsn
 
+              - name: SENTRY_ENVIRONMENT
+                value: ${ENV_NAME}
+
             resources:
               limits:
                 cpu: "${CPU_LIMIT_SERVICE}"
@@ -237,9 +240,6 @@ parameters:
 
   - name: ROADMAP_DB_SECRET_NAME
     value: roadmap-db
-
-  - name: SENTRY_ENVIRONMENT
-    description: Environment name for Setry
 
   - name: ROADMAP_HOST_INVENTORY_URL
 

--- a/src/roadmap/main.py
+++ b/src/roadmap/main.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import sentry_sdk
 
@@ -13,20 +14,21 @@ import roadmap.v1
 from roadmap.common import HealtCheckFilter
 
 
-sentry_sdk.init(
-    traces_sample_rate=1.0,
-    profiles_sample_rate=1.0,
-    integrations=[
-        FastApiIntegration(
-            failed_request_status_codes={403, 404, *range(500, 599)},
-            http_methods_to_capture=("GET",),
-        ),
-        StarletteIntegration(
-            failed_request_status_codes={403, 404, *range(500, 599)},
-            http_methods_to_capture=("GET",),
-        ),
-    ],
-)
+if os.getenv("SENTRY_DSN"):
+    sentry_sdk.init(
+        traces_sample_rate=1.0,
+        profiles_sample_rate=1.0,
+        integrations=[
+            FastApiIntegration(
+                failed_request_status_codes={403, 404, *range(500, 599)},
+                http_methods_to_capture=("GET",),
+            ),
+            StarletteIntegration(
+                failed_request_status_codes={403, 404, *range(500, 599)},
+                http_methods_to_capture=("GET",),
+            ),
+        ],
+    )
 
 logging.getLogger("uvicorn.access").addFilter(HealtCheckFilter())
 


### PR DESCRIPTION
Use `ENV_NAME` for the Sentry environment instead of having a separate parameter. If we need to break these out separately, we can do that in the future.