### PR TITLE
Remove 'digital-' prefix from make tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT_DIR=$(shell pwd)
 
-VENV_DIR=.venvs/digital_roadmap
+VENV_DIR=.venvs/roadmap
 PYTHON ?= $(shell which python || which python3)
 VENV_PYTHON=$(VENV_DIR)/bin/python
 PYTHON_VERSION = $(shell $(VENV_PYTHON) -V | cut -d ' ' -f 2 | cut -d '.' -f 1,2)
@@ -12,7 +12,7 @@ PRE_COMMIT=$(VENV_DIR)/bin/pre-commit
 
 export PIP_DISABLE_PIP_VERSION_CHECK = 1
 
-ROADMAP_DB_IMAGE ?= quay.io/samdoran/digital-roadmap-data
+ROADMAP_DB_IMAGE ?= quay.io/samdoran/roadmap-data
 ROADMAP_DB_PORT ?= 5432
 
 # Set the shell because otherwise this defaults to /bin/sh,
@@ -55,11 +55,11 @@ endif
 
 .PHONY: start-db
 start-db: stop-db
-	$(CONTAINER_RUNTIME) run --rm -d -p $(ROADMAP_DB_PORT):5432 --name digital-roadmap-data $(ROADMAP_DB_IMAGE)
+	$(CONTAINER_RUNTIME) run --rm -d -p $(ROADMAP_DB_PORT):5432 --name roadmap-data $(ROADMAP_DB_IMAGE)
 
 .PHONY: stop-db
 stop-db: check-container-runtime
-	@$(CONTAINER_RUNTIME) stop digital-roadmap-data > /dev/null 2>&1 || true
+	@$(CONTAINER_RUNTIME) stop roadmap-data > /dev/null 2>&1 || true
 	@sleep 0.1
 
 .PHONY: run
@@ -84,4 +84,4 @@ test:
 
 .PHONY: build
 build: check-container-runtime
-	$(CONTAINER_RUNTIME) build -t digital-roadmap:latest -f Containerfile .
+	$(CONTAINER_RUNTIME) build -t roadmap:latest -f Containerfile .

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Alternatively you may create your own virtual environment, install the requireme
 ```
 # After creating and activating a virtual environment
 pip install -r requirements/requirements-dev-{Python version}.txt
-fastapi run src/roadmap/main.py --reload --host 127.0.0.1 --port 8000
+uvicorn --app-dir src "roadmap.main:app" --reload --reload-dir src --host 127.0.0.1 --port 8000 --log-level debug
 ```
 
 The database runs in a container and contains data already. To specify a different container image, set `DB_IMAGE`.


### PR DESCRIPTION
Change default virtual environment name, database container name, and name of the application container image.

This will required recreating the default virtual environment and manually cleaning up the old one.
```
# Cleanup
[docker|podman] stop digital-roadmap-data
rm -rf .venvs/digital_roadmap

# Start fresh
make install-dev
make start-db
```