### PR TITLE
[RSPEED-907] Do not redirect trailing slashes

### DIFF
--- a/src/roadmap/main.py
+++ b/src/roadmap/main.py
@@ -34,7 +34,7 @@ logging.getLogger("uvicorn.access").addFilter(HealtCheckFilter())
 
 
 # Initialize FastAPI app
-app = FastAPI()
+app = FastAPI(redirect_slashes=False)
 
 # Add Prometheus metrics
 instrumentor = Instrumentator()

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -141,7 +141,7 @@ router = APIRouter(
 )
 
 
-@router.get("/", response_model=AppStreamsResponse)
+@router.get("", response_model=AppStreamsResponse)
 async def get_app_streams(filter_params: AppStreamFilter):
     result = APP_STREAM_MODULES_PACKAGES
     result = await filter_app_stream_results(result, filter_params)
@@ -201,7 +201,7 @@ relevant = APIRouter(
 )
 
 
-@relevant.get("/", response_model=RelevantAppStreamsResponse)
+@relevant.get("", response_model=RelevantAppStreamsResponse)
 async def get_relevant_app_streams(  # noqa: C901
     authorization: t.Annotated[str | None, Header(include_in_schema=False)] = None,
     user_agent: t.Annotated[str | None, Header(include_in_schema=False)] = None,

--- a/src/roadmap/v1/lifecycle/rhel.py
+++ b/src/roadmap/v1/lifecycle/rhel.py
@@ -41,7 +41,7 @@ class LifecycleResponse(BaseModel):
     data: list[RHELLifecycle]
 
 
-@router.get("/", summary="Return lifecycle data for all RHEL versions", response_model=LifecycleResponse)
+@router.get("", summary="Return lifecycle data for all RHEL versions", response_model=LifecycleResponse)
 async def get_systems():
     return {"data": get_lifecycle_data()}
 
@@ -81,7 +81,7 @@ relevant = APIRouter(
 
 @relevant.get("/{major}/{minor}")
 @relevant.get("/{major}")
-@relevant.get("/")
+@relevant.get("")
 async def get_relevant_systems(
     authorization: t.Annotated[str | None, Header(include_in_schema=False)] = None,
     user_agent: t.Annotated[str | None, Header(include_in_schema=False)] = None,

--- a/src/roadmap/v1/release_notes.py
+++ b/src/roadmap/v1/release_notes.py
@@ -14,7 +14,7 @@ from roadmap.models import TaggedParagraph
 router = APIRouter(prefix="/release-notes", tags=["Release Notes"])
 
 
-@router.get("/")
+@router.get("")
 async def get_release_notes(
     major: int = Query(..., description="Major version number"),
     minor: int = Query(..., description="Minor version number"),

--- a/src/roadmap/v1/upcoming.py
+++ b/src/roadmap/v1/upcoming.py
@@ -6,7 +6,7 @@ from roadmap.data import UPCOMING_DATA
 router = APIRouter(prefix="/upcoming-changes", tags=["Upcoming Changes"])
 
 
-@router.get("/")
+@router.get("")
 async def get_upcoming():
     # TODO: Replace fixture data with data from database
     return UPCOMING_DATA

--- a/tests/v1/lifecycle/test_app_streams.py
+++ b/tests/v1/lifecycle/test_app_streams.py
@@ -37,7 +37,7 @@ def test_get_app_streams_by_version(api_prefix, client, version):
 
 
 def test_get_app_streams_by_name(api_prefix, client):
-    result = client.get(f"{api_prefix}/lifecycle/app-streams/", params={"name": "nginx"})
+    result = client.get(f"{api_prefix}/lifecycle/app-streams", params={"name": "nginx"})
     data = result.json().get("data", [])
     names = set(item["name"] for item in data)
 
@@ -65,7 +65,7 @@ def test_get_app_stream_stream_names(api_prefix, client, version):
 
 
 def test_get_app_stream_module_info(api_prefix, client):
-    result = client.get(f"{api_prefix}/lifecycle/app-streams/8/", params={"name": "nginx"})
+    result = client.get(f"{api_prefix}/lifecycle/app-streams/8", params={"name": "nginx"})
     data = result.json().get("data", "")
     module_names = set(module["name"] for module in data)
 
@@ -75,7 +75,7 @@ def test_get_app_stream_module_info(api_prefix, client):
 
 
 def test_get_app_stream_module_info_not_found(api_prefix, client):
-    result = client.get(f"{api_prefix}/lifecycle/app-streams/8/", params={"name": "NOPE"})
+    result = client.get(f"{api_prefix}/lifecycle/app-streams/8", params={"name": "NOPE"})
     data = result.json().get("data", "")
 
     assert result.status_code == 200
@@ -86,7 +86,7 @@ def test_get_relevant_app_stream(api_prefix, client, mocker, read_json_fixture):
     mock_response = read_json_fixture("inventory_response_packages.json.gz")
     mocker.patch("roadmap.v1.lifecycle.app_streams.query_host_inventory", return_value=mock_response)
 
-    result = client.get(f"{api_prefix}/relevant/lifecycle/app-streams/")
+    result = client.get(f"{api_prefix}/relevant/lifecycle/app-streams")
     data = result.json().get("data", "")
 
     assert result.status_code == 200
@@ -98,7 +98,7 @@ def test_get_relevant_app_stream_error(api_prefix, client, mocker, read_json_fix
     mocker.patch("roadmap.v1.lifecycle.app_streams.query_host_inventory", return_value=mock_response)
     mocker.patch("roadmap.v1.lifecycle.app_streams.RelevantAppStream", side_effect=ValueError("Raised intentionally"))
 
-    result = client.get(f"{api_prefix}/relevant/lifecycle/app-streams/")
+    result = client.get(f"{api_prefix}/relevant/lifecycle/app-streams")
     detail = result.json().get("detail", "")
 
     assert result.status_code == 400

--- a/tests/v1/test_upcoming.py
+++ b/tests/v1/test_upcoming.py
@@ -1,3 +1,3 @@
 def test_get_upcoming_changes(client, api_prefix):
-    response = client.get(f"{api_prefix}/upcoming-changes/")
+    response = client.get(f"{api_prefix}/upcoming-changes")
     assert response.status_code == 200


### PR DESCRIPTION
Despite my best efforts, I have not found a way to redirect to the correct hostname. It always redirects to the internal hostname, which is obviously not helpful.

Instead, change APIs to not have a trailing slash and disable automatic 307 redirects. This means a 404 will be returned for API requests with a trailing slash.