### PR TITLE
[RSPEED-963] Add start and end dates for packages

### DIFF
--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -94,6 +94,8 @@ class AppStreamCount(BaseModel):
     stream: str
     impl: AppStreamImplementation
     rolling: bool = False
+    start_date: date | None = None
+    end_date: date | None = None
 
 
 class RelevantAppStream(BaseModel):
@@ -281,6 +283,8 @@ async def get_relevant_app_streams(  # noqa: C901
                     os_lifecycle=os_lifecycle if app_stream_package.rolling else None,
                     rolling=app_stream_package.rolling,
                     impl=AppStreamImplementation.package,
+                    start_date=app_stream_package.start_date,
+                    end_date=app_stream_package.end_date,
                 )
                 app_stream_counts.add(count_key)
 
@@ -304,6 +308,8 @@ async def get_relevant_app_streams(  # noqa: C901
                 impl=count_key.impl,
                 count=count,
                 rolling=count_key.rolling,
+                start_date=count_key.start_date,
+                end_date=count_key.end_date,
             )
             response.append(value_to_add)
         except Exception as exc:


### PR DESCRIPTION
The data weren't set anywhere which resulted in mising graph in web UI.

TODO:
- add the dates also for the `APP_STREAM_MODULES`. The date needs to be found based on the
`dnf_module["name"], dnf_module["stream"]` which should be unique key for getting date.