### PR TITLE
Add tooling to load host inventory data for development and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Run PostgreSQL
         run: make start-db
 
+      - name: Load test data
+        run: make install-dev load-host-data
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ stop-db: check-container-runtime
 	@$(CONTAINER_RUNTIME) stop roadmap-data > /dev/null 2>&1 || true
 	@sleep 0.1
 
+.PHONY: load-host-data
+load-host-data:
+	@PYTHONPATH=./src/ $(VENV_PYTHON) $(PROJECT_DIR)/scripts/load_host_data.py
+
 .PHONY: run
 run:
 	$(VENV_DIR)/bin/uvicorn --app-dir src "roadmap.main:app" --reload --reload-dir src --host 127.0.0.1 --port 8000 --log-level debug

--- a/README.md
+++ b/README.md
@@ -53,21 +53,11 @@ Create a virtual environment, install the requirements, and run the server.
 
 ```shell
 make install
-make start-db run
+make start-db load-host-data run
 ```
 
 This runs a server using the default virtual environment. Documentation can be found at  `http://127.0.0.1:8000/docs`.
 
-### Relevant APIs
-
-The `/relevant/` APIs query [host inventory] in order to return relevant results. To avoid querying the inventory API and return fixture data, set `ROADMAP_DEV=1` in the environment.
-
-```
-export ROADMAP_DEV=1
-make run
-```
-
-This will return data from [tests/fixtures/](tests/fixtures), making it easy to change the response for testing and development.
 
 ### Getting a token for accessing Red Hat APIs
 
@@ -86,11 +76,12 @@ http localhost:8000/api/roadmap/v1/relevant/lifecycle/rhel/ \
 ```
 
 ## Developer Guide
-Install the developer tools and run the server.
+Install the developer tools, load test data, and run the server. Setting `ROADMAP_DEV=1` will avoid querying RBAC and query inventory data in the local database.
 
 ```shell
+export ROADMAP_DEV=1
 make install-dev
-make start-db run
+make start-db load-host-data run
 ```
 
 Alternatively you may create your own virtual environment, install the requirements, and run the server manually.

--- a/requirements/requirements-dev-3.12.txt
+++ b/requirements/requirements-dev-3.12.txt
@@ -7,6 +7,7 @@ distlib==0.3.9
 executing==2.2.0
 filelock==3.17.0
 identify==2.6.9
+Faker==37.1.0
 ipdb==0.13.13
 ipython==9.0.2
 ipython_pygments_lexers==1.1.1

--- a/requirements/requirements-dev-3.13.txt
+++ b/requirements/requirements-dev-3.13.txt
@@ -7,6 +7,7 @@ distlib==0.3.9
 executing==2.2.0
 filelock==3.17.0
 identify==2.6.9
+Faker==37.1.0
 ipdb==0.13.13
 ipython==9.0.2
 ipython_pygments_lexers==1.1.1
@@ -25,4 +26,5 @@ PyYAML==6.0.2
 stack-data==0.6.3
 traitlets==5.14.3
 virtualenv==20.29.3
+tzdata==2025.2
 wcwidth==0.2.13

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -1,3 +1,4 @@
+faker
 ipdb
 ipython
 pre-commit

--- a/scripts/load_host_data.py
+++ b/scripts/load_host_data.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+
+import gzip
+
+from datetime import datetime
+from datetime import timedelta
+from pathlib import Path
+from uuid import uuid4
+
+from app_common_python import json
+from faker import Faker
+from sqlalchemy import create_engine
+from sqlalchemy import delete
+from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.ddl import CreateSchema
+from sqlalchemy.types import JSON
+from sqlalchemy.types import String
+from sqlalchemy.types import TIMESTAMP
+from sqlalchemy.types import UUID
+
+from roadmap.config import Settings
+
+
+class HBI(DeclarativeBase):
+    __table_args__ = {"schema": "hbi"}
+
+
+class Host(HBI):
+    __tablename__ = "hosts"
+
+    id: Mapped[UUID] = mapped_column(UUID(), primary_key=True)
+    account: Mapped[str | None] = mapped_column(String(30), nullable=True, default=None)
+    display_name: Mapped[str] = mapped_column(String(200))
+    created_on: Mapped[TIMESTAMP] = mapped_column(TIMESTAMP())
+    modified_on: Mapped[TIMESTAMP] = mapped_column(TIMESTAMP())
+    facts: Mapped[JSON] = mapped_column(JSON(), nullable=True, default={})
+    tags: Mapped[JSON] = mapped_column(JSON(), nullable=True, default={})
+    canonical_facts: Mapped[JSON] = mapped_column(JSON(), nullable=True, default={})
+    system_profile_facts: Mapped[JSON] = mapped_column(JSON(), nullable=True, default={})
+    ansible_host: Mapped[str] = mapped_column(String(255))
+    stale_timestamp: Mapped[TIMESTAMP] = mapped_column(TIMESTAMP())
+    reporter: Mapped[str] = mapped_column(String(255))
+    per_reporter_staleness: Mapped[JSON] = mapped_column(JSON(), default={})
+    org_id: Mapped[str] = mapped_column(String(36))
+    groups: Mapped[JSON] = mapped_column(JSON(), default=[])
+    tags_alt: Mapped[JSON] = mapped_column(JSON(), nullable=True, default=[{}])
+    last_check_in: Mapped[TIMESTAMP] = mapped_column(TIMESTAMP())
+
+
+def main():
+    fake = Faker()
+    settings = Settings.create()
+    engine = create_engine(str(settings.database_url), echo=True)
+    with engine.connect() as connection:
+        # Create the schema
+        connection.execute(CreateSchema("hbi", if_not_exists=True))
+        connection.commit()
+
+    # Create the table and table schema
+    Host.metadata.create_all(engine)
+
+    # Use data in the file to populate the database
+    response_data_file = Path(__file__).parent.parent / "tests" / "fixtures" / "inventory_db_response.json.gz"
+    with gzip.open(response_data_file) as gzfile:
+        host_data = json.load(gzfile)
+
+    # Build the records
+    records = []
+    for n in range(len(host_data)):
+        id = uuid4()
+        init_date = fake.date_time_between(start_date="-1w")
+
+        records.append(
+            Host(
+                id=id,
+                display_name=f"{id.hex[:6]}.foo.redhat.com",
+                created_on=init_date,
+                modified_on=init_date,
+                system_profile_facts=host_data[n].get("system_profile_facts", {}),
+                ansible_host="ansible_host",
+                stale_timestamp=init_date + timedelta(30),
+                reporter="toast loader",
+                per_reporter_staleness={},
+                org_id="1234",
+                groups=[],
+                tags_alt=[],
+                last_check_in=datetime.now(),
+            )
+        )
+
+    # Write the records to the database but first delete all existing records
+    with Session(engine) as session:
+        session.execute(delete(Host))
+        session.add_all(records)
+        session.commit()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -1,5 +1,4 @@
 import base64
-import gzip
 import json
 import logging
 import typing as t
@@ -7,7 +6,6 @@ import urllib.parse
 import urllib.request
 
 from datetime import date
-from pathlib import Path
 from urllib.error import HTTPError
 
 from fastapi import Depends
@@ -116,28 +114,6 @@ async def query_host_inventory(
     if settings.dev:
         if not org_id:
             org_id = "1234"
-
-        logger.debug("Running in development mode. Returning fixture response data for inventory.")
-        file = Path(__file__).resolve()
-        response_data_file = file.parent.parent.parent / "tests" / "fixtures" / "inventory_db_response.json.gz"
-        with gzip.open(response_data_file) as gzfile:
-            response_data = json.load(gzfile)
-
-        if major is not None:
-            response_data = [
-                item
-                for item in response_data
-                if item.get("system_profile_facts", {}).get("operating_system", {}).get("major") == major
-            ]
-
-        if minor is not None:
-            response_data = [
-                item
-                for item in response_data
-                if item.get("system_profile_facts", {}).get("operating_system", {}).get("minor") == minor
-            ]
-
-        return response_data
 
     if groups:
         # TODO: Implement group filtering

--- a/tests/v1/lifecycle/test_app_streams.py
+++ b/tests/v1/lifecycle/test_app_streams.py
@@ -5,7 +5,7 @@ from urllib.error import HTTPError
 
 import pytest
 
-from roadmap.common import query_host_inventory
+from roadmap.common import decode_header
 from roadmap.common import query_rbac
 from roadmap.config import Settings
 from roadmap.data.app_streams import AppStreamEntity
@@ -88,7 +88,7 @@ def test_get_app_stream_module_info_not_found(api_prefix, client):
     assert len(data) == 0
 
 
-def test_get_relevant_app_stream(api_prefix, client, read_json_fixture):
+def test_get_relevant_app_stream(api_prefix, client):
     async def query_rbac_override():
         return [
             {
@@ -97,12 +97,12 @@ def test_get_relevant_app_stream(api_prefix, client, read_json_fixture):
             }
         ]
 
-    async def query_host_inventory_override():
-        return read_json_fixture("inventory_db_response.json.gz")
+    async def decode_header_override():
+        return "1234"
 
     client.app.dependency_overrides = {}
     client.app.dependency_overrides[query_rbac] = query_rbac_override
-    client.app.dependency_overrides[query_host_inventory] = query_host_inventory_override
+    client.app.dependency_overrides[decode_header] = decode_header_override
     result = client.get(f"{api_prefix}/relevant/lifecycle/app-streams")
     data = result.json().get("data", "")
 
@@ -128,7 +128,7 @@ def test_get_relevant_app_stream_error(api_prefix, client, mocker):
     assert detail == "Raised intentionally"
 
 
-def test_get_relevant_app_stream_error_building_response(api_prefix, client, read_json_fixture, mocker):
+def test_get_relevant_app_stream_error_building_response(api_prefix, client, mocker):
     async def query_rbac_override():
         return [
             {
@@ -137,12 +137,12 @@ def test_get_relevant_app_stream_error_building_response(api_prefix, client, rea
             }
         ]
 
-    async def query_host_inventory_override():
-        return read_json_fixture("inventory_db_response.json.gz")
+    async def decode_header_override():
+        return "1234"
 
     client.app.dependency_overrides = {}
     client.app.dependency_overrides[query_rbac] = query_rbac_override
-    client.app.dependency_overrides[query_host_inventory] = query_host_inventory_override
+    client.app.dependency_overrides[decode_header] = decode_header_override
     mocker.patch("roadmap.v1.lifecycle.app_streams.RelevantAppStream", side_effect=ValueError("Raised intentionally"))
 
     result = client.get(f"{api_prefix}/relevant/lifecycle/app-streams")

--- a/tests/v1/lifecycle/test_rhel.py
+++ b/tests/v1/lifecycle/test_rhel.py
@@ -1,6 +1,6 @@
 import pytest
 
-from roadmap.common import query_host_inventory
+from roadmap.common import decode_header
 from roadmap.common import query_rbac
 from roadmap.models import System
 
@@ -41,7 +41,7 @@ def test_rhel_lifecycle_major_minor_version(client, api_prefix, params):
     assert (major, minor) == tuple(int(v) for v in params.split("/"))
 
 
-def test_rhel_relevant(client, api_prefix, read_json_fixture):
+def test_rhel_relevant(client, api_prefix):
     async def query_rbac_override():
         return [
             {
@@ -50,12 +50,12 @@ def test_rhel_relevant(client, api_prefix, read_json_fixture):
             }
         ]
 
-    async def query_host_inventory_override():
-        return read_json_fixture("inventory_db_response.json.gz")
+    async def decode_header_override():
+        return "1234"
 
     client.app.dependency_overrides = {}
     client.app.dependency_overrides[query_rbac] = query_rbac_override
-    client.app.dependency_overrides[query_host_inventory] = query_host_inventory_override
+    client.app.dependency_overrides[decode_header] = decode_header_override
 
     response = client.get(f"{api_prefix}/relevant/lifecycle/rhel")
     data = response.json()["data"]


### PR DESCRIPTION
This will create a new schema, `hbi`, and a new table `hosts` and load hosts from the fixture file. Then we are able to use that data is development and testing.

A new make target runs the loading program. It can be run many times and will remove all the existing host records before inserting again.

```
export ROADMAP_DEV=1
make start-db
make load-host-data
make run
```

The `/relevant/` APIs will query host inventory data.
```
http localhost:8000/api/roadmap/v1/relevant/lifecycle/app-streams
http localhost:8000/api/roadmap/v1/relevant/lifecycle/rhel
```

## Summary by Sourcery

Add tooling to load host inventory data for local development and testing environments

New Features:
- Create a new database schema and table to load host inventory data for local development
- Implement a script to populate the host inventory database with test data from fixtures

Enhancements:
- Remove hardcoded fixture data loading from query function
- Update README and Makefile to support loading host data during development

Build:
- Update development requirements files

Chores:
- Add a new Python script to manage host data loading
- Create a new database schema and host table for local testing