### PR TITLE
Get database streaming working again

### DIFF
--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -126,7 +126,7 @@ async def query_host_inventory(
     if minor is not None:
         query = f"{query} AND system_profile_facts #>> '{{operating_system,minor}}' = :minor"
 
-    result = await session.execute(
+    result = await session.stream(
         text(query),
         params={
             "org_id": org_id,
@@ -134,7 +134,7 @@ async def query_host_inventory(
             "minor": str(minor),
         },
     )
-    return result.mappings().all()
+    yield result
 
 
 def get_lifecycle_type(products: list[dict[str, str]]) -> LifecycleType:

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -215,7 +215,7 @@ async def get_relevant_app_streams(  # noqa: C901
     # Get a count of each module and package based on OS and OS lifecycle
     module_count = defaultdict(int)
     missing = defaultdict(int)
-    for system in inventory_result:
+    async for system in inventory_result.mappings():
         system_profile = system.get("system_profile_facts")
         if not system_profile:
             missing["system_profile"] += 1

--- a/src/roadmap/v1/lifecycle/rhel.py
+++ b/src/roadmap/v1/lifecycle/rhel.py
@@ -89,7 +89,7 @@ async def get_relevant_systems(  # noqa: C901
 ) -> RelevantSystemsResponse:
     system_counts = defaultdict(int)
     missing = defaultdict(int)
-    for result in systems:
+    async for result in systems.mappings():
         system_profile = result.get("system_profile_facts")
         if not system_profile:
             missing["system_profile"] += 1


### PR DESCRIPTION
Go back to streaming the results from the database.

I needed to yield a single item from FastAPI's dependency injection machinery and do the `mappings()` call in the path function.

Depends on #118
