### PR TITLE
Rename API deployment

### DIFF
--- a/deploy/config.yml
+++ b/deploy/config.yml
@@ -21,7 +21,7 @@ objects:
         version: 16
 
       deployments:
-        - name: roadmap-api  # Would changing this to just API break 3scale?
+        - name: api
           minReplicas: ${{MIN_REPLICAS}}
           deploymentStrategy:
             privateStrategy: RollingUpdate


### PR DESCRIPTION
Reduce name duplication since Clowder creates items with an app name prefix.

This may break the 3Scale connectivity.