### PR TITLE
[RSPEED-730] Remove path params for /relevant/ API endpoints

### DIFF
--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -11,6 +11,7 @@ from urllib.error import HTTPError
 from fastapi import Depends
 from fastapi import Header
 from fastapi import HTTPException
+from fastapi import Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import text
 
@@ -20,6 +21,9 @@ from roadmap.models import LifecycleType
 
 
 logger = logging.getLogger("uvicorn.error")
+
+MajorVersion = t.Annotated[int | None, Query(description="Major version number", ge=8, le=10)]
+MinorVersion = t.Annotated[int | None, Query(description="Minor version number", ge=0, le=10)]
 
 
 class HealthCheckFilter(logging.Filter):
@@ -108,8 +112,8 @@ async def query_host_inventory(
     session: t.Annotated[AsyncSession, Depends(get_db)],
     settings: t.Annotated[Settings, Depends(Settings.create)],
     groups: t.Annotated[list[str], Depends(check_inventory_access)],
-    major: int | None = None,
-    minor: int | None = None,
+    major: MajorVersion = None,
+    minor: MinorVersion = None,
 ):
     if settings.dev:
         org_id = "1234"

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -6,10 +6,10 @@ from datetime import date
 from uuid import UUID
 
 from fastapi import APIRouter
+from fastapi import Depends
 from fastapi import Path
+from fastapi import Query
 from fastapi.exceptions import HTTPException
-from fastapi.param_functions import Query
-from fastapi.params import Depends
 from pydantic import AfterValidator
 from pydantic import BaseModel
 from pydantic import ConfigDict
@@ -35,7 +35,7 @@ from roadmap.models import SupportStatus
 logger = logging.getLogger("uvicorn.error")
 
 Date = t.Annotated[str | date | None, AfterValidator(ensure_date)]
-RHELMajorVersion = t.Annotated[int, Path(description="Major RHEL version", ge=8, le=10)]
+MajorVersion = t.Annotated[int | None, Path(description="Major version number", ge=8, le=10)]
 
 
 def get_rolling_value(name: str, stream: str, os_major: int) -> bool:
@@ -154,7 +154,7 @@ async def get_app_streams(filter_params: AppStreamFilter):
 
 @router.get("/{major_version}", response_model=AppStreamsResponse)
 async def get_major_version(
-    major_version: RHELMajorVersion,
+    major_version: MajorVersion,
     filter_params: AppStreamFilter,
 ):
     result = [module for module in APP_STREAM_MODULES_PACKAGES if module.os_major == major_version]
@@ -168,7 +168,7 @@ async def get_major_version(
 
 @router.get("/{major_version}/packages", response_model=AppStreamsNamesResponse)
 async def get_app_stream_item_names(
-    major_version: RHELMajorVersion,
+    major_version: MajorVersion,
     filter_params: AppStreamFilter,
 ):
     result = [module for module in APP_STREAM_MODULES_PACKAGES if module.os_major == major_version]
@@ -182,7 +182,7 @@ async def get_app_stream_item_names(
 
 @router.get("/{major_version}/streams", response_model=AppStreamsNamesResponse)
 async def get_app_stream_names(
-    major_version: RHELMajorVersion,
+    major_version: MajorVersion,
     filter_params: AppStreamFilter,
 ):
     result = [module for module in APP_STREAM_MODULES_PACKAGES if module.os_major == major_version]

--- a/src/roadmap/v1/lifecycle/rhel.py
+++ b/src/roadmap/v1/lifecycle/rhel.py
@@ -80,8 +80,6 @@ relevant = APIRouter(
 )
 
 
-@relevant.get("/{major}/{minor}")
-@relevant.get("/{major}")
 @relevant.get("")
 async def get_relevant_systems(
     org_id: t.Annotated[str, Depends(decode_header)],

--- a/src/roadmap/v1/lifecycle/rhel.py
+++ b/src/roadmap/v1/lifecycle/rhel.py
@@ -29,8 +29,8 @@ router = APIRouter(
     tags=["RHEL"],
 )
 
-MajorVersion = t.Annotated[int, Path(description="Major version number", ge=8, le=10)]
-MinorVersion = t.Annotated[int, Path(description="Minor version number", ge=0, le=10)]
+MajorVersion = t.Annotated[int | None, Path(description="Major version number", ge=8, le=10)]
+MinorVersion = t.Annotated[int | None, Path(description="Minor version number", ge=0, le=10)]
 
 
 class RelevantSystemsResponse(BaseModel):


### PR DESCRIPTION
Trying to make the relevant API work with both query and path parameters
got really messy. Rather than fighting it, just go with query parameters
only for the relevant APIs.