### PR TITLE
Handle a few more special cases for app stream names

### DIFF
--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -44,6 +44,7 @@ def get_display_name(app_stream: AppStreamEntity) -> str:
 
     special_case = {
         "apache httpd": "Apache HTTPD",
+        "freeradius": "FreeRADIUS",
         "llvm": "LLVM",
         "mariadb": "MariaDB",
         "mod_auth_openidc for apache": "Mod Auth OpenIDC for Apache",

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -51,6 +51,7 @@ def get_display_name(app_stream: AppStreamEntity) -> str:
         "nginx": "NGINX",
         "node.js": "Node.js",
         "nodejs": "Node.js",
+        "openjdk": "OpenJDK",
         "osinfo-db": "OSInfo DB",
         "php": "PHP",
         "postgresql": "PostgreSQL",

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -46,7 +46,7 @@ def get_display_name(app_stream: AppStreamEntity) -> str:
         "apache httpd": "Apache HTTPD",
         "llvm": "LLVM",
         "mariadb": "MariaDB",
-        "mod_auth_openidc": "Mod Auth OpenIDC",
+        "mod_auth_openidc for apache": "Mod Auth OpenIDC for Apache",
         "mysql": "MySQL",
         "nginx": "NGINX",
         "node.js": "Node.js",
@@ -57,7 +57,6 @@ def get_display_name(app_stream: AppStreamEntity) -> str:
         "postgresql": "PostgreSQL",
         "rhn-tools": "RHN Tools",
     }
-
     display_name = app_stream.name
     if app_stream.application_stream_name and app_stream.application_stream_name != "Unknown":
         display_name = app_stream.application_stream_name
@@ -67,7 +66,7 @@ def get_display_name(app_stream: AppStreamEntity) -> str:
         version = ".".join(app_stream.stream.split(".")[:2])
 
         # Avoid putting a duplicate string at the end
-        if version and display_name[-len(version) :] != version:
+        if version and display_name[-len(version) :].lower() != version:
             display_name = f"{display_name.rstrip()} {version}"
 
     # Correct capitalization


### PR DESCRIPTION
FreeRADIUS and OpenJDK needed a special case. Identity Management Client uses a value for `stream` than is not a digit. To avoid duplicating the version in the display name, compare the end of the string in lowercase.