### PR TITLE
[RSPEED-1144] Unset certain environment variables during testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,14 @@ def client():
     return TestClient(app)
 
 
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    """Unset these environment variables during testing"""
+    unset = ("ROADMAP_DEV",)
+    for var in unset:
+        monkeypatch.delenv(var, raising=False)
+
+
 @pytest.fixture
 def read_json_fixture():
     fixture_path = Path(__file__).parent.joinpath("fixtures").resolve()


### PR DESCRIPTION
`ROADMAP_DEV` is never meant to be set globally during a test run. Add a fixture to unset it for all tests. Tests are still able to set environment variables if needed.

This could also be inverted to a list of environment variables to _allow_ in the testing environment. Starting simple, though.


<details>
  <summary>Example test run</summary>
  
```
> ROADMAP_DEV=1 pytest
/Users/sdoran/.pyenv/versions/3.12.9/envs/dr-backend-3.12.9/lib/python3.12/site-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
========================================================================================= test session starts ==========================================================================================
platform darwin -- Python 3.12.9, pytest-8.3.5, pluggy-1.5.0 -- /Users/sdoran/.pyenv/versions/3.12.9/envs/dr-backend-3.12.9/bin/python
cachedir: .pytest_cache
rootdir: /Users/sdoran/Developer/digital-roadmap-backend
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.9.0, Faker-37.1.0, asyncio-0.26.0, mock-3.14.0, cov-6.1.1, xdist-3.6.1
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 78 items

tests/test_common.py::test_query_host_inventory PASSED                                                                                                                                           [  1%]
tests/test_common.py::test_query_host_inventory_major[7] PASSED                                                                                                                                  [  2%]
tests/test_common.py::test_query_host_inventory_major[8] PASSED                                                                                                                                  [  3%]
tests/test_common.py::test_query_host_inventory_major[9] PASSED                                                                                                                                  [  5%]
tests/test_common.py::test_query_host_inventory_major_minor[9-5] PASSED                                                                                                                          [  6%]
tests/test_common.py::test_query_host_inventory_major_minor[9-0] PASSED                                                                                                                          [  7%]
tests/test_common.py::test_query_host_inventory_major_minor[8-1] PASSED                                                                                                                          [  8%]
tests/test_common.py::test_query_host_inventory_major_minor[8-0] PASSED                                                                                                                          [ 10%]
tests/test_common.py::test_query_host_inventory_groups PASSED                                                                                                                                    [ 11%]
tests/test_common.py::test_query_host_inventory_dev PASSED                                                                                                                                       [ 12%]
tests/test_common.py::test_query_host_inventory_dev_org_id[8765309-20] PASSED                                                                                                                    [ 14%]
tests/test_common.py::test_query_host_inventory_dev_org_id[None-20] PASSED                                                                                                                       [ 15%]
tests/test_common.py::test_ensure_date[20250101] PASSED                                                                                                                                          [ 16%]
tests/test_common.py::test_ensure_date[2025-01-01] PASSED                                                                                                                                        [ 17%]
tests/test_common.py::test_ensure_date_error[1000] PASSED                                                                                                                                        [ 19%]
tests/test_common.py::test_ensure_date_error[101] PASSED                                                                                                                                         [ 20%]
tests/test_common.py::test_decode_header[None-] PASSED                                                                                                                                           [ 21%]
tests/test_common.py::test_decode_header[eyJpZGVudGl0eSI6IHsib3JnX2lkIjogIjMxNDE1OTcifX0=-3141597] PASSED                                                                                        [ 23%]
tests/test_common.py::test_query_rbac PASSED                                                                                                                                                     [ 24%]
tests/test_common.py::test_query_rbac_error PASSED                                                                                                                                               [ 25%]
tests/test_common.py::test_query_rbac_dev_mode PASSED                                                                                                                                            [ 26%]
tests/test_common.py::test_query_rbac_no_url PASSED                                                                                                                                              [ 28%]
tests/test_common.py::test_check_inventory_access PASSED                                                                                                                                         [ 29%]
tests/test_common.py::test_check_inventory_no_access[permissions0] PASSED                                                                                                                        [ 30%]
tests/test_common.py::test_check_inventory_no_access[permissions1] PASSED                                                                                                                        [ 32%]
tests/test_common.py::test_check_inventory_no_access[permissions2] PASSED                                                                                                                        [ 33%]
tests/test_config.py::test_default_settings PASSED                                                                                                                                               [ 34%]
tests/test_config.py::test_settings_db_user PASSED                                                                                                                                               [ 35%]
tests/test_config.py::test_setting_from_clowder PASSED                                                                                                                                           [ 37%]
tests/test_config.py::test_rbac_config_defaults PASSED                                                                                                                                           [ 38%]
tests/test_config.py::test_rbac_config_env PASSED                                                                                                                                                [ 39%]
tests/test_main.py::test_ping PASSED                                                                                                                                                             [ 41%]
tests/test_main.py::test_metrics PASSED                                                                                                                                                          [ 42%]
tests/test_main.py::test_openapi_docs_root PASSED                                                                                                                                                [ 43%]
tests/test_main.py::test_openapi_docs_v1 PASSED                                                                                                                                                  [ 44%]
tests/test_models.py::test_calculate_support_status_system[current_date0-system_start0-system_end0-Supported] PASSED                                                                             [ 46%]
tests/test_models.py::test_calculate_support_status_system[current_date1-system_start1-system_end1-Support ends within 6 months] PASSED                                                          [ 47%]
tests/test_models.py::test_calculate_support_status_system[current_date2-system_start2-system_end2-Retired] PASSED                                                                               [ 48%]
tests/test_models.py::test_calculate_support_status_system[current_date3-system_start3-system_end3-Upcoming release] PASSED                                                                      [ 50%]
tests/test_models.py::test_calculate_support_status_system[current_date4-system_start4-None-Unknown] PASSED                                                                                      [ 51%]
tests/test_models.py::test_calculate_support_status_system[current_date5-None-system_end5-Supported] PASSED                                                                                      [ 52%]
tests/test_models.py::test_calculate_support_status_system[current_date6-None-None-Unknown] PASSED                                                                                               [ 53%]
tests/v1/lifecycle/test_app_streams.py::test_get_app_streams PASSED                                                                                                                              [ 55%]
tests/v1/lifecycle/test_app_streams.py::test_get_app_streams_filter PASSED                                                                                                                       [ 56%]
tests/v1/lifecycle/test_app_streams.py::test_get_app_streams_by_version[8] PASSED                                                                                                                [ 57%]
tests/v1/lifecycle/test_app_streams.py::test_get_app_streams_by_version[9] PASSED                                                                                                                [ 58%]
tests/v1/lifecycle/test_app_streams.py::test_get_app_streams_by_name PASSED                                                                                                                      [ 60%]
tests/v1/lifecycle/test_app_streams.py::test_get_app_stream_package_names[8] PASSED                                                                                                              [ 61%]
tests/v1/lifecycle/test_app_streams.py::test_get_app_stream_package_names[9] PASSED                                                                                                              [ 62%]
tests/v1/lifecycle/test_app_streams.py::test_get_app_stream_stream_names[8] PASSED                                                                                                               [ 64%]
tests/v1/lifecycle/test_app_streams.py::test_get_app_stream_stream_names[9] PASSED                                                                                                               [ 65%]
tests/v1/lifecycle/test_app_streams.py::test_get_app_stream_module_info PASSED                                                                                                                   [ 66%]
tests/v1/lifecycle/test_app_streams.py::test_get_app_stream_module_info_not_found PASSED                                                                                                         [ 67%]
tests/v1/lifecycle/test_app_streams.py::test_get_relevant_app_stream PASSED                                                                                                                      [ 69%]
tests/v1/lifecycle/test_app_streams.py::test_get_relevant_app_stream_error PASSED                                                                                                                [ 70%]
tests/v1/lifecycle/test_app_streams.py::test_get_relevant_app_stream_error_building_response PASSED                                                                                              [ 71%]
tests/v1/lifecycle/test_app_streams.py::test_get_relevant_app_stream_no_rbac_access PASSED                                                                                                       [ 73%]
tests/v1/lifecycle/test_app_streams.py::test_app_stream_missing_lifecycle_data PASSED                                                                                                            [ 74%]
tests/v1/lifecycle/test_app_streams.py::test_app_stream_package_no_start_date PASSED                                                                                                             [ 75%]
tests/v1/lifecycle/test_app_streams.py::test_app_stream_package_missing_rhel_data PASSED                                                                                                         [ 76%]
tests/v1/lifecycle/test_app_streams.py::test_app_stream_package_single_digit PASSED                                                                                                              [ 78%]
tests/v1/lifecycle/test_app_streams.py::test_calculate_support_status_appstream[current_date0-app_stream_start0-app_stream_end0-Supported] PASSED                                                [ 79%]
tests/v1/lifecycle/test_app_streams.py::test_calculate_support_status_appstream[current_date1-app_stream_start1-app_stream_end1-Support ends within 6 months] PASSED                             [ 80%]
tests/v1/lifecycle/test_app_streams.py::test_calculate_support_status_appstream[current_date2-app_stream_start2-app_stream_end2-Retired] PASSED                                                  [ 82%]
tests/v1/lifecycle/test_app_streams.py::test_calculate_support_status_appstream[current_date3-app_stream_start3-app_stream_end3-Upcoming release] PASSED                                         [ 83%]
tests/v1/lifecycle/test_app_streams.py::test_calculate_support_status_appstream[current_date4-app_stream_start4-None-Unknown] PASSED                                                             [ 84%]
tests/v1/lifecycle/test_app_streams.py::test_calculate_support_status_appstream[current_date5-None-app_stream_end5-Supported] PASSED                                                             [ 85%]
tests/v1/lifecycle/test_app_streams.py::test_calculate_support_status_appstream[current_date6-None-None-Unknown] PASSED                                                                          [ 87%]
tests/v1/lifecycle/test_rhel.py::test_rhel_lifecycle PASSED                                                                                                                                      [ 88%]
tests/v1/lifecycle/test_rhel.py::test_rhel_lifecycle_major_version PASSED                                                                                                                        [ 89%]
tests/v1/lifecycle/test_rhel.py::test_rhel_lifecycle_major_minor_version[9/0] PASSED                                                                                                             [ 91%]
tests/v1/lifecycle/test_rhel.py::test_rhel_lifecycle_major_minor_version[9/1] PASSED                                                                                                             [ 92%]
tests/v1/lifecycle/test_rhel.py::test_rhel_lifecycle_major_minor_version[8/2] PASSED                                                                                                             [ 93%]
tests/v1/lifecycle/test_rhel.py::test_rhel_lifecycle_major_minor_version[8/0] PASSED                                                                                                             [ 94%]
tests/v1/lifecycle/test_rhel.py::test_rhel_relevant PASSED                                                                                                                                       [ 96%]
tests/v1/lifecycle/test_rhel.py::test_get_relevant_rhel_no_rbac_access PASSED                                                                                                                    [ 97%]
tests/v1/test_upcoming.py::test_get_upcoming_changes PASSED                                                                                                                                      [ 98%]
tests/v1/test_upcoming.py::test_get_upcoming_changes_with_env PASSED                                                                                                                             [100%]

============================================================================================ tests coverage ============================================================================================
___________________________________________________________________________ coverage: platform darwin, python 3.12.9-final-0 ___________________________________________________________________________

Name                                      Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------------------------
src/roadmap/common.py                        91      1     30      0    99%   31
src/roadmap/config.py                        46      0      6      1    98%   69->76
src/roadmap/main.py                          24      1      2      1    92%   18
src/roadmap/v1/lifecycle/app_streams.py     199     27     48      2    83%   265-291, 293-319
src/roadmap/v1/lifecycle/rhel.py             83     28     18      2    60%   96-140, 142
-------------------------------------------------------------------------------------
TOTAL                                       662     57    122      6    89%

10 files skipped due to complete coverage.
Coverage HTML written to dir htmlcov
========================================================================================= slowest 10 durations =========================================================================================

(10 durations < 1s hidden.  Use -vv to show these durations.)
========================================================================================== 78 passed in 1.98s ==========================================================================================
```
</details>