### PR TITLE
Capture coverage data for all relevant concurrency types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,5 +44,9 @@ addopts = [
     "--pdbcls", "IPython.terminal.debugger:TerminalPdb",
 ]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
 testpaths = "tests"
 pythonpath = "src"
+
+[tool.coverage.run]
+concurrency = ["greenlet", "thread"]


### PR DESCRIPTION
This fixes missing coverage in some of our code.