### PR TITLE
Add `display_name` to RHEL lifecycle response

### DIFF
--- a/src/roadmap/models.py
+++ b/src/roadmap/models.py
@@ -75,11 +75,21 @@ class Lifecycle(BaseModel):
 
 class RHELLifecycle(Lifecycle):
     name: str = "RHEL"
+    display_name: str = ""
     major: int
     minor: int | None = None
     end_e4s: date | None = None
     end_els: date | None = None
     end_eus: date | None = None
+
+    @model_validator(mode="after")
+    def set_display_name(self):
+        if not self.display_name:
+            self.display_name = f"{self.name} {self.major}"
+            if self.minor is not None:
+                self.display_name += f".{self.minor}"
+
+        return self
 
 
 class ReleaseModel(BaseModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,7 @@ from datetime import date
 
 import pytest
 
+from roadmap.models import _get_rhel_display_name
 from roadmap.models import LifecycleType
 from roadmap.models import SupportStatus
 from roadmap.models import System
@@ -78,3 +79,14 @@ def test_calculate_support_status_system(mocker, current_date, system_start, sys
     )
 
     assert app_stream.support_status == status
+
+
+@pytest.mark.parametrize(
+    ("name", "major", "minor", "expected"),
+    (
+        ("RHEL", 8, None, "RHEL 8"),
+        ("RHEL", 9, 0, "RHEL 9.0"),
+    ),
+)
+def test_get_rhel_display_name(name, major, minor, expected):
+    assert _get_rhel_display_name(name, major, minor) == expected


### PR DESCRIPTION
This makes the API response consistent with recent changes to the app streams API.