### PR TITLE
[RSPEED-1232] Change settings precedence

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 from fastapi.testclient import TestClient
 
+from roadmap.config import Settings
 from roadmap.main import app
 
 
@@ -21,6 +22,11 @@ def clean_env(monkeypatch):
     unset = ("ROADMAP_DEV",)
     for var in unset:
         monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache():
+    Settings.create.cache_clear()
 
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,11 +11,6 @@ def unset_acg_config(monkeypatch):
     monkeypatch.delenv("ACG_CONFIG", raising=False)
 
 
-@pytest.fixture(autouse=True)
-def clear_settings_cache():
-    Settings.create.cache_clear()
-
-
 def test_default_settings(monkeypatch):
     monkeypatch.delenv("ROADMAP_DB_USER", raising=False)
 
@@ -76,7 +71,6 @@ def test_rbac_config_env_override_clowder(monkeypatch):
     monkeypatch.setenv("ROADMAP_DB_HOST", "WOOF.com")
     monkeypatch.setenv("ROADMAP_DB_PORT", "6753")
     settings = Settings.create()
-    Settings.create.cache_clear()
 
     assert settings.db_name == "roadtrip-db"
     assert settings.db_user == "thelma"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,3 +66,24 @@ def test_rbac_config_env(monkeypatch):
     assert settings.rbac_hostname == "example.com"
     assert settings.rbac_port == 8080
     assert settings.rbac_url == "http://example.com:8080"
+
+
+def test_rbac_config_env_override_clowder(monkeypatch):
+    monkeypatch.setenv("ACG_CONFIG", os.path.join(os.getcwd(), "tests", "fixtures", "clowder_config.json"))
+    monkeypatch.setenv("ROADMAP_DB_NAME", "roadtrip-db")
+    monkeypatch.setenv("ROADMAP_DB_USER", "thelma")
+    monkeypatch.setenv("ROADMAP_DB_PASSWORD", "FRS635")
+    monkeypatch.setenv("ROADMAP_DB_HOST", "WOOF.com")
+    monkeypatch.setenv("ROADMAP_DB_PORT", "6753")
+    settings = Settings.create()
+    Settings.create.cache_clear()
+
+    assert settings.db_name == "roadtrip-db"
+    assert settings.db_user == "thelma"
+    assert settings.db_password.get_secret_value() == "FRS635"
+    assert settings.db_host == "WOOF.com"
+    assert settings.db_port == 6753
+    assert (
+        settings.database_url.encoded_string()
+        == "postgresql+psycopg://thelma:FRS635@WOOF.com:6753/roadtrip-db"  # notsecret
+    )

--- a/tests/v1/test_upcoming.py
+++ b/tests/v1/test_upcoming.py
@@ -11,9 +11,7 @@ def test_get_upcoming_changes(client, api_prefix):
 
 def test_get_upcoming_changes_with_env(client, api_prefix):
     def settings_override():
-        return Settings(
-            upcoming_json_path=str(Path(__file__).parent.parent.joinpath("fixtures").joinpath("upcoming.json"))
-        )
+        return Settings(upcoming_json_path=Path(__file__).parent.parent.joinpath("fixtures").joinpath("upcoming.json"))
 
     client.app.dependency_overrides = {}
     client.app.dependency_overrides[Settings.create] = settings_override


### PR DESCRIPTION
Environment variables now override Clowder config items for database settings. Hopefully this is a temporary change since database parameters and RBAC parameters now have a different precedence order.