### PR TITLE
[RSPEED-1234] Return system IDs from relevant RHEL API

### DIFF
--- a/src/roadmap/models.py
+++ b/src/roadmap/models.py
@@ -3,6 +3,7 @@ import typing as t
 from datetime import date
 from datetime import timedelta
 from enum import StrEnum
+from uuid import UUID
 
 from pydantic import BaseModel
 from pydantic import ConfigDict
@@ -74,6 +75,7 @@ class System(Lifecycle):
     count: int = 0
     lifecycle_type: LifecycleType
     related: bool = False
+    systems: list[UUID] = []
 
     @model_validator(mode="after")
     def set_display_name(self):

--- a/src/roadmap/v1/lifecycle/rhel.py
+++ b/src/roadmap/v1/lifecycle/rhel.py
@@ -89,7 +89,7 @@ async def get_relevant_systems(  # noqa: C901
 ) -> RelevantSystemsResponse:
     system_counts = defaultdict(int)
     missing = defaultdict(int)
-    systems_by_version = defaultdict(list)
+    systems_by_version_lifecycle = defaultdict(list)
     async for result in systems.mappings():
         system_profile = result.get("system_profile_facts")
         if not system_profile:
@@ -106,10 +106,10 @@ async def get_relevant_systems(  # noqa: C901
         os_minor = system_profile.get("operating_system", {}).get("minor")
         lifecycle_type = get_lifecycle_type(installed_products)
 
-        # Collect system IDs by major minor version so we can return those in the response
+        # Collect system IDs by major version, minor version, and lifecycle type so we can return those in the response
         system_id = result["id"]
-        key = str(os_major) if os_minor is None else f"{os_major}.{os_minor}"
-        systems_by_version[key].append(system_id)
+        system_id_key = (str(os_major) if os_minor is None else f"{os_major}.{os_minor}", lifecycle_type)
+        systems_by_version_lifecycle[system_id_key].append(system_id)
 
         count_key = HostCount(name=name, major=os_major, minor=os_minor, lifecycle=lifecycle_type)
         system_counts[count_key] += 1
@@ -118,6 +118,7 @@ async def get_relevant_systems(  # noqa: C901
     system_keys = set()
     for count_key, count in system_counts.items():
         key = str(count_key.major) if count_key.minor is None else f"{count_key.major}.{count_key.minor}"
+        system_id_key = (key, count_key.lifecycle)
         system_keys.add(key)
         try:
             lifecycle_info = OS_LIFECYCLE_DATES[key]
@@ -145,7 +146,7 @@ async def get_relevant_systems(  # noqa: C901
                 end_date=end_date,
                 count=count,
                 related=False,
-                systems=systems_by_version[key],
+                systems=systems_by_version_lifecycle[system_id_key],
             )
         )
 

--- a/tests/v1/lifecycle/test_rhel.py
+++ b/tests/v1/lifecycle/test_rhel.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 
 from roadmap.common import decode_header
@@ -62,6 +64,8 @@ def test_rhel_relevant(client, api_prefix):
 
     assert len(data) > 1
     assert data[0].keys() == System.model_fields.keys()
+    assert len(data[0]["systems"]) > 0  # There should be system IDs
+    assert uuid.UUID(data[0]["systems"][0])  # The system ID should be a valid UUID
 
 
 def test_get_relevant_rhel_no_rbac_access(api_prefix, client):
@@ -94,6 +98,7 @@ def test_rhel_relevant_related(client, api_prefix):
 
     response = client.get(f"{api_prefix}/relevant/lifecycle/rhel?related=true")
     data = response.json()["data"]
+    related_hosts = [item for item in data if not item["count"]]
 
     assert len(data) > 1
-    assert data[0].keys() == System.model_fields.keys()
+    assert len(related_hosts) > 1

--- a/tests/v1/lifecycle/test_rhel.py
+++ b/tests/v1/lifecycle/test_rhel.py
@@ -66,6 +66,8 @@ def test_rhel_relevant(client, api_prefix):
     assert data[0].keys() == System.model_fields.keys()
     assert len(data[0]["systems"]) > 0  # There should be system IDs
     assert uuid.UUID(data[0]["systems"][0])  # The system ID should be a valid UUID
+    for item in data:
+        assert item["count"] == len(item["systems"]), "Mismatch between count and number of system IDs"
 
 
 def test_get_relevant_rhel_no_rbac_access(api_prefix, client):


### PR DESCRIPTION
This makes the `/api/roadmap/v1/relevant/lifecycle/rhel` match the behavior of `/api/roadmap/v1/relevant/lifecycle/app-streams`.

<details>
  <summary>Example output</summary>
  
```
> http localhost:8000/api/roadmap/v1/relevant/lifecycle/rhel
{
    "meta": {
        "count": 20,
        "total": 81
    },
    "data": [
        {
            "name": "RHEL",
            "display_name": "RHEL 9.6",
            "major": 9,
            "minor": 6,
            "release_date": "2025-05-15",
            "retirement_date": "2025-11-30",
            "support_status": "Upcoming release",
            "count": 2,
            "lifecycle_type": "mainline",
            "related": false,
            "systems": [
                "22fdb977-29f7-4b7c-9e11-1abe299edb4c",
                "ead7f218-4b43-4a7c-9006-dd49a73961b2"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 9.5",
            "major": 9,
            "minor": 5,
            "release_date": "2024-11-12",
            "retirement_date": "2025-05-31",
            "support_status": "Support ends within 6 months",
            "count": 15,
            "lifecycle_type": "mainline",
            "related": false,
            "systems": [
                "3b94f2c9-f43c-40b4-9685-d703f56bc8c7",
                "006d269e-d8e1-4e1a-bd09-c3805ce46ea7",
                "d4e5c3fe-838e-49ed-9c23-4292dc582ee4",
                "3ab12a2b-36c2-43c8-9b71-444b402c97a7",
                "ee68b8a6-95e3-47d8-98c0-aa1a3c592224",
                "2a9e0b29-f852-48cd-8326-aa9180cbfeba",
                "af8d65f9-4ba4-4967-aedc-52ffcdaf2884",
                "82b66a4e-ddd0-4299-a1d2-da0d1ce7e894",
                "038f5189-166d-4e97-8f8f-46d2736301b4",
                "3f477ab3-6ef2-4e02-8eca-7d8444ed8398",
                "1a22b37d-2ea1-47f8-979c-e8e69db0dcd2",
                "db1a7cf9-4c99-486f-9da8-eab037ee5a26",
                "29ad58de-4e19-45f3-bf38-0d4f36fa7f41",
                "16ad9d67-b7cb-40e7-a343-ef1895295592",
                "33cc7f2d-5945-453e-8575-eaf1c509c23f"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 9.4",
            "major": 9,
            "minor": 4,
            "release_date": "2024-04-30",
            "retirement_date": "2024-10-31",
            "support_status": "Retired",
            "count": 17,
            "lifecycle_type": "mainline",
            "related": false,
            "systems": [
                "02cbf1ea-f610-44f3-92de-331b4f552d45",
                "601553e5-5ed7-46de-be17-30bc70d0ff6f",
                "542d7147-3a8b-43a1-9b16-06b45ecef34e",
                "f62d1b1c-262c-46ef-a42b-c6ab75dd52f6",
                "bad01d4f-1acc-4348-8933-9e20b002e8c8",
                "a58362a3-5de2-432a-893d-72c0cb097a56",
                "91b4fe82-ef72-46f6-94fe-f1ad65e1674b",
                "e8de4c7e-8b22-4f17-a06d-5d91cadc2da6",
                "c712eb04-8916-4784-86df-02437dff42fc",
                "40613a5d-863f-466f-b046-e91821aa998f",
                "106dffe9-eec7-4039-83d4-a4e987a6420b",
                "7ae447c3-fd5a-406a-8e7e-6489f851f26f",
                "4eeb0d46-72df-4df9-a403-bb5ea9e03f63",
                "51926718-2e8c-4599-959f-566ed09c686a",
                "63eca892-19c7-45a0-87f2-066ece464b7d",
                "d54d9db7-88b9-4ccf-98e1-59df4ef22a51",
                "a45cf575-fc99-47c0-a984-2d53598316c5",
                "1005abbe-3444-4293-8e7c-0ac566900231",
                "b87d6bc7-693d-448b-b59b-c13417705bbc",
                "cfa5688e-083b-459e-b8b6-fc53370bde1a",
                "57f913e2-2c3e-4436-8563-bffd1677f6e3"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 9.3",
            "major": 9,
            "minor": 3,
            "release_date": "2023-11-07",
            "retirement_date": "2024-05-31",
            "support_status": "Retired",
            "count": 2,
            "lifecycle_type": "mainline",
            "related": false,
            "systems": [
                "191eca62-1aed-407d-88c7-82e0d8846004",
                "55c25e7f-a75b-48d1-846d-ccaaafbb520f"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 9.2",
            "major": 9,
            "minor": 2,
            "release_date": "2023-05-10",
            "retirement_date": "2023-11-30",
            "support_status": "Retired",
            "count": 2,
            "lifecycle_type": "mainline",
            "related": false,
            "systems": [
                "e469224b-0a08-44c7-89fd-f01c04da64a3",
                "2c5db6f9-434b-4dd1-8eb5-7af20eb6af62"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 9.1",
            "major": 9,
            "minor": 1,
            "release_date": "2022-11-15",
            "retirement_date": "2023-05-31",
            "support_status": "Retired",
            "count": 12,
            "lifecycle_type": "mainline",
            "related": false,
            "systems": [
                "023c4b26-2832-4a33-bd9c-00b77052aa6f",
                "e84bad16-abea-4c36-b00b-6e710f04910e",
                "95633364-e619-4371-84f0-3ae019a55f3a",
                "2a2a6482-7f27-4418-9971-5e504e55d786",
                "758e0d8c-8cba-40eb-b864-356eb4fc8894",
                "2e155326-fe14-4eb8-bea5-429c73fb2a78",
                "d839929f-3ae6-45a7-b466-7a986634fed7",
                "553446bd-d093-4df8-8a64-cd889f6258a3",
                "7e534e19-2553-4dc0-a7ae-9511e82ca492",
                "0cfe3589-69d0-46b4-b89c-97bb123aa2ba",
                "8c49738b-e5fe-4430-8289-4b1a5929aa40",
                "05e10221-f5b5-4078-ba5f-dba554ccd9ec"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 9.0",
            "major": 9,
            "minor": 0,
            "release_date": "2022-05-18",
            "retirement_date": "2022-11-30",
            "support_status": "Retired",
            "count": 1,
            "lifecycle_type": "mainline",
            "related": false,
            "systems": [
                "cc8937f1-0c2f-48cf-a547-b0af47437fda"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 8.10",
            "major": 8,
            "minor": 10,
            "release_date": "2024-05-22",
            "retirement_date": "2029-05-31",
            "support_status": "Supported",
            "count": 12,
            "lifecycle_type": "mainline",
            "related": false,
            "systems": [
                "6d4e295d-4664-4c3f-89f4-03d347cce452",
                "58a92c4d-5917-49a9-a864-1acf2189d323",
                "4e7de60a-5244-4e57-ac30-35b199559200",
                "c2e25917-d8a3-46c8-b75b-5f38afc78b89",
                "1cf49d86-36e6-44e5-aa0b-f1e1d36ea488",
                "ac0f58bb-2803-46c1-a7fb-971710dc5fa7",
                "c9109ad6-9e1e-4fb4-87a4-9d404d2d5983",
                "f801440a-4aa2-459f-a350-950898676671",
                "d013cc77-8d31-4e79-b843-9cd5a6c859f8",
                "018294b3-851f-4b23-b34d-d7a705898a3d",
                "ad7a8ed2-e0ab-4507-9ce3-52a9561608e4",
                "f5aa381c-ef50-4c8d-8c59-c29c45c97c38"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 8.9",
            "major": 8,
            "minor": 9,
            "release_date": "2023-11-14",
            "retirement_date": "2024-05-31",
            "support_status": "Retired",
            "count": 1,
            "lifecycle_type": "mainline",
            "related": false,
            "systems": [
                "5a04e213-31c5-4b17-87b7-1ef90542fee4"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 8.8",
            "major": 8,
            "minor": 8,
            "release_date": "2023-05-16",
            "retirement_date": "2023-11-30",
            "support_status": "Retired",
            "count": 4,
            "lifecycle_type": "mainline",
            "related": false,
            "systems": [
                "c0882361-1680-4844-aa69-820a3825996f",
                "845095ec-9894-4346-9c7d-886bd4d686a8",
                "422a7c5b-cece-4c89-b820-b60323d562bf",
                "7448e9b9-312d-4882-8c5a-2e8140a299ab",
                "75b6766e-3d5d-40d6-be81-48d4a804b24b"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 8.7",
            "major": 8,
            "minor": 7,
            "release_date": "2022-11-09",
            "retirement_date": "2023-05-31",
            "support_status": "Retired",
            "count": 1,
            "lifecycle_type": "mainline",
            "related": false,
            "systems": [
                "b76c4c8e-565c-495c-bc9e-e7c7d08314f0"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 8.5",
            "major": 8,
            "minor": 5,
            "release_date": "2021-11-09",
            "retirement_date": "2022-05-31",
            "support_status": "Retired",
            "count": 1,
            "lifecycle_type": "mainline",
            "related": false,
            "systems": [
                "bc4c5e2c-427b-4824-8bb4-cec542b5199e"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 8.3",
            "major": 8,
            "minor": 3,
            "release_date": "2020-11-03",
            "retirement_date": "2021-05-31",
            "support_status": "Retired",
            "count": 1,
            "lifecycle_type": "mainline",
            "related": false,
            "systems": [
                "c09194e6-6432-45e1-bf66-7cbc21cd9749"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 8.1",
            "major": 8,
            "minor": 1,
            "release_date": "2019-11-05",
            "retirement_date": "2020-05-31",
            "support_status": "Retired",
            "count": 2,
            "lifecycle_type": "mainline",
            "related": false,
            "systems": [
                "91a76eba-fcc1-4881-8a19-30541f52a402",
                "60ce9eb1-d6e0-43e8-8063-ce2b009fae1c"
            ]
        },
        {
            "name": "CentOS",
            "display_name": "CentOS 8.0",
            "major": 8,
            "minor": 0,
            "release_date": "2019-05-07",
            "retirement_date": "2019-11-30",
            "support_status": "Retired",
            "count": 1,
            "lifecycle_type": "mainline",
            "related": false,
            "systems": [
                "7efdebe2-91e5-4490-b6db-1de2076f3f08"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 7.9",
            "major": 7,
            "minor": 9,
            "release_date": "Unknown",
            "retirement_date": "Unknown",
            "support_status": "Unknown",
            "count": 1,
            "lifecycle_type": "mainline",
            "related": false,
            "systems": [
                "0c6909ac-954d-440c-bf06-8837091c6560"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 9.4",
            "major": 9,
            "minor": 4,
            "release_date": "2024-04-30",
            "retirement_date": "2024-10-31",
            "support_status": "Retired",
            "count": 3,
            "lifecycle_type": "EUS",
            "related": false,
            "systems": [
                "02cbf1ea-f610-44f3-92de-331b4f552d45",
                "601553e5-5ed7-46de-be17-30bc70d0ff6f",
                "542d7147-3a8b-43a1-9b16-06b45ecef34e",
                "f62d1b1c-262c-46ef-a42b-c6ab75dd52f6",
                "bad01d4f-1acc-4348-8933-9e20b002e8c8",
                "a58362a3-5de2-432a-893d-72c0cb097a56",
                "91b4fe82-ef72-46f6-94fe-f1ad65e1674b",
                "e8de4c7e-8b22-4f17-a06d-5d91cadc2da6",
                "c712eb04-8916-4784-86df-02437dff42fc",
                "40613a5d-863f-466f-b046-e91821aa998f",
                "106dffe9-eec7-4039-83d4-a4e987a6420b",
                "7ae447c3-fd5a-406a-8e7e-6489f851f26f",
                "4eeb0d46-72df-4df9-a403-bb5ea9e03f63",
                "51926718-2e8c-4599-959f-566ed09c686a",
                "63eca892-19c7-45a0-87f2-066ece464b7d",
                "d54d9db7-88b9-4ccf-98e1-59df4ef22a51",
                "a45cf575-fc99-47c0-a984-2d53598316c5",
                "1005abbe-3444-4293-8e7c-0ac566900231",
                "b87d6bc7-693d-448b-b59b-c13417705bbc",
                "cfa5688e-083b-459e-b8b6-fc53370bde1a",
                "57f913e2-2c3e-4436-8563-bffd1677f6e3"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 8.8",
            "major": 8,
            "minor": 8,
            "release_date": "2023-05-16",
            "retirement_date": "2023-11-30",
            "support_status": "Retired",
            "count": 1,
            "lifecycle_type": "EUS",
            "related": false,
            "systems": [
                "c0882361-1680-4844-aa69-820a3825996f",
                "845095ec-9894-4346-9c7d-886bd4d686a8",
                "422a7c5b-cece-4c89-b820-b60323d562bf",
                "7448e9b9-312d-4882-8c5a-2e8140a299ab",
                "75b6766e-3d5d-40d6-be81-48d4a804b24b"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 9.10",
            "major": 9,
            "minor": 10,
            "release_date": "2027-05-15",
            "retirement_date": "2035-05-31",
            "support_status": "Upcoming release",
            "count": 1,
            "lifecycle_type": "ELS",
            "related": false,
            "systems": [
                "4816daee-7b72-4496-ad60-b35228d06591"
            ]
        },
        {
            "name": "RHEL",
            "display_name": "RHEL 9.4",
            "major": 9,
            "minor": 4,
            "release_date": "2024-04-30",
            "retirement_date": "2028-04-30",
            "support_status": "Supported",
            "count": 1,
            "lifecycle_type": "E4S",
            "related": false,
            "systems": [
                "02cbf1ea-f610-44f3-92de-331b4f552d45",
                "601553e5-5ed7-46de-be17-30bc70d0ff6f",
                "542d7147-3a8b-43a1-9b16-06b45ecef34e",
                "f62d1b1c-262c-46ef-a42b-c6ab75dd52f6",
                "bad01d4f-1acc-4348-8933-9e20b002e8c8",
                "a58362a3-5de2-432a-893d-72c0cb097a56",
                "91b4fe82-ef72-46f6-94fe-f1ad65e1674b",
                "e8de4c7e-8b22-4f17-a06d-5d91cadc2da6",
                "c712eb04-8916-4784-86df-02437dff42fc",
                "40613a5d-863f-466f-b046-e91821aa998f",
                "106dffe9-eec7-4039-83d4-a4e987a6420b",
                "7ae447c3-fd5a-406a-8e7e-6489f851f26f",
                "4eeb0d46-72df-4df9-a403-bb5ea9e03f63",
                "51926718-2e8c-4599-959f-566ed09c686a",
                "63eca892-19c7-45a0-87f2-066ece464b7d",
                "d54d9db7-88b9-4ccf-98e1-59df4ef22a51",
                "a45cf575-fc99-47c0-a984-2d53598316c5",
                "1005abbe-3444-4293-8e7c-0ac566900231",
                "b87d6bc7-693d-448b-b59b-c13417705bbc",
                "cfa5688e-083b-459e-b8b6-fc53370bde1a",
                "57f913e2-2c3e-4436-8563-bffd1677f6e3"
            ]
        }
    ]
}
```
</details>