### PR TITLE
Faild build when data file is unavailable

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -57,9 +57,11 @@ RUN useradd --key HOME_MODE=0755 --system --create-home --home-dir /srv/roady ro
 COPY /src/roadmap/ /srv/roady/roadmap/
 COPY /scripts/replication.py /usr/local/bin/replication.py
 
-RUN curl --insecure \
+RUN curl \
+    --insecure \
+    --fail \
     --output /srv/roady/roadmap/data/upcoming.json \
-    "https://gitlab.cee.redhat.com/api/v4/projects/107966/repository/files/data%2F02_roadmap_jira.json/raw?ref=develop"
+    "https://gitlab.cee.redhat.com/api/v4/projects/107966/repository/files/data%2F02_roadmap_jira.json/raw?ref=main"
 
 USER roady
 WORKDIR /srv/roady


### PR DESCRIPTION
Instead of silently including an invalid file, fail the build.

The `develop` branch went away in the data repo. Update to the correct ref.