### PR TITLE
[RSPEED-1454] Improve database engine creation and make pool size configurable

### DIFF
--- a/deploy/config.yml
+++ b/deploy/config.yml
@@ -70,6 +70,12 @@ objects:
                     name: ${ROADMAP_DB_SECRET_NAME}
                     key: db.password
 
+              - name: ROADMAP_DB_POOL_SIZE
+                value: ${ROADMAP_DB_POOL_SIZE}
+
+              - name: ROADMAP_DB_MAX_OVERFLOW
+                value: ${ROADMAP_DB_MAX_OVERFLOW}
+
               - name: SENTRY_DSN
                 valueFrom:
                   secretKeyRef:
@@ -234,6 +240,12 @@ parameters:
 
   - name: ROADMAP_DB_SECRET_NAME
     value: host-inventory-db-readonly
+
+  - name: ROADMAP_DB_POOL_SIZE
+    value: ""
+
+  - name: ROADMAP_DB_MAX_OVERFLOW
+    value: ""
 
   - name: DB_NAME
     required: true

--- a/src/roadmap/config.py
+++ b/src/roadmap/config.py
@@ -20,6 +20,8 @@ class Settings(BaseSettings):
     db_password: SecretStr = SecretStr("postgres")
     db_host: str = "localhost"
     db_port: int = 5432
+    db_pool_size: int = 10
+    db_max_overflow: int = 20
     debug: bool = False
     dev: bool = False
     host_inventory_url: str = "https://console.redhat.com"

--- a/src/roadmap/database.py
+++ b/src/roadmap/database.py
@@ -1,14 +1,22 @@
-import typing as t
-
-from fastapi import Depends
 from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from roadmap.config import Settings
 
 
-async def get_db(settings: t.Annotated[Settings, Depends(Settings.create)]):
-    engine = create_async_engine(str(settings.database_url), echo=True)
-    async_session = async_sessionmaker(engine, expire_on_commit=False)
+SETTINGS = Settings.create()
+ENGINE = create_async_engine(
+    str(SETTINGS.database_url),
+    echo=True,
+    pool_size=SETTINGS.db_pool_size,
+    max_overflow=SETTINGS.db_max_overflow,
+)
+
+
+async def get_db():
+    # Docs for connections and transactions that explain pool_size and max_overflow
+    #   https://docs.sqlalchemy.org/en/20/errors.html#error-3o7r
+
+    async_session = async_sessionmaker(ENGINE, expire_on_commit=False)
     async with async_session() as session:
         yield session

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -20,7 +20,7 @@ from roadmap.database import get_db
 @pytest.fixture(scope="module")
 async def base_args():
     settings = Settings.create()
-    session = await anext(get_db(settings))
+    session = await anext(get_db())
     return {
         "org_id": "1234",
         "session": session,


### PR DESCRIPTION
The database _engine_ should be created only once and reused for the life of the application. The _session_ should be opened and closed for each API request.

Add two new settings for controlling the connection pool size, `ROADMAP_DB_POOL_SIZE`, and the maximum number of connections that can be created, `ROADMAP_DB_MAX_OVERFLOW`. The total number of connections is `pool_size` + `max_overflow`. After that, SQLAlchemy will raise errors.

https://fastapi.tiangolo.com/tutorial/sql-databases/
https://docs.sqlalchemy.org/en/20/errors.html#error-3o7r