### PR TITLE
Ignore non-host RBAC permissions

### DIFF
--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -96,16 +96,13 @@ async def check_inventory_access(
 
     Return list of resource definitions and permission.
     """
-    inventory_access_perms = {"inventory:*:*", "inventory:hosts:read"}
+    inventory_access_perms = {"inventory:*:*", "inventory:*:read", "inventory:hosts:read"}
+    host_permissions = [p for p in permissions if p.get("permission") in inventory_access_perms]
 
-    has_access = False
-    if any(permission.get("permission") in inventory_access_perms for permission in permissions):
-        has_access = True
-
-    if not has_access:
+    if not host_permissions:
         raise HTTPException(status_code=403, detail="Not authorized to access host inventory")
 
-    return permissions
+    return host_permissions
 
 
 # FIXME: This should be cached

--- a/tests/v1/lifecycle/test_app_streams.py
+++ b/tests/v1/lifecycle/test_app_streams.py
@@ -189,6 +189,35 @@ def test_get_relevant_app_stream_resource_definitions(api_prefix, client):
     assert "not yet implemented" in result.json()["detail"].casefold()
 
 
+def test_get_relevant_app_stream_resource_definitions_with_group_restriction(api_prefix, client):
+    """Testing a specific case that used to cause 501s"""
+    async def query_rbac_override():
+        return [
+            {"permission": "inventory:hosts:read", "resourceDefinitions": []},
+            {"permission": "inventory:groups:write", "resourceDefinitions": []},
+            {"permission": "inventory:groups:read", "resourceDefinitions": []},
+            {
+                "permission": "inventory:groups:read",
+                "resourceDefinitions": [
+                    {
+                        "attributeFilter": {
+                            "key": "group.id",
+                            "operation": "in",
+                            "value": ["c22abc43-62f9-4a03-94e0-2a49d0e3c3d8"],
+                        }
+                    }
+                ],
+            },
+        ]
+
+    client.app.dependency_overrides = {}
+    client.app.dependency_overrides[query_rbac] = query_rbac_override
+
+    result = client.get(f"{api_prefix}/relevant/lifecycle/app-streams")
+
+    assert result.status_code == 200
+
+
 def test_get_revelent_app_stream_related(api_prefix, client):
     async def query_rbac_override():
         return [

--- a/tests/v1/lifecycle/test_app_streams.py
+++ b/tests/v1/lifecycle/test_app_streams.py
@@ -191,6 +191,7 @@ def test_get_relevant_app_stream_resource_definitions(api_prefix, client):
 
 def test_get_relevant_app_stream_resource_definitions_with_group_restriction(api_prefix, client):
     """Testing a specific case that used to cause 501s"""
+
     async def query_rbac_override():
         return [
             {"permission": "inventory:hosts:read", "resourceDefinitions": []},


### PR DESCRIPTION

We were rejecting requests when RBAC was returning permissions like this:

```[{'permission': 'inventory:hosts:write', 'resourceDefinitions': []},
 {'permission': 'inventory:hosts:read', 'resourceDefinitions': []},
 {'permission': 'inventory:groups:write', 'resourceDefinitions': []},
 {'permission': 'inventory:groups:read', 'resourceDefinitions': []},
 {'permission': 'inventory:groups:read',
  'resourceDefinitions': [{'attributeFilter': {'key': 'group.id',
                                               'operation': 'in',
                                               'value': ['c22abc43-62f9-4a03-94e0-2a49d0e3c3d8']}}]}]
```

the populated resourceDefinition was in inventory:groups, when our query only pertains to inventory:hosts.

this PR has our code filter out permissions that do not pertain to hosts before analyzing them. This prevents an RBAC result like the one above from causing a 501.