### PR TITLE
Properly parse package names that are missing the expected delimiter

### DIFF
--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -311,7 +311,12 @@ class StringPackage(BaseModel, frozen=True):
 
     @classmethod
     def from_string(cls, s):
-        name, major = s.split(":")
+        name, _, major = s.partition(":")
+        if not major:
+            # Missing ':' in the expected package name. Partition on '-' instead.
+            #   Example: cairo-1.15.12-3.el8.x86_64
+            name, _, major = s.partition("-")
+
         name = name.rsplit("-", 1)[0]
         major = major.split(".")[0]
         return cls(name=name, major=major)

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -311,11 +311,11 @@ class StringPackage(BaseModel, frozen=True):
 
     @classmethod
     def from_string(cls, s):
-        name, _, major = s.partition(":")
-        if not major:
+        name, separator, major = s.partition(":")
+        if not separator:
             # Missing ':' in the expected package name. Partition on '-' instead.
             #   Example: cairo-1.15.12-3.el8.x86_64
-            name, _, major = s.partition("-")
+            name, separator, major = s.partition("-")
 
         name = name.rsplit("-", 1)[0]
         major = major.split(".")[0]

--- a/tests/v1/lifecycle/test_app_streams.py
+++ b/tests/v1/lifecycle/test_app_streams.py
@@ -12,6 +12,7 @@ from roadmap.data.app_streams import AppStreamEntity
 from roadmap.models import SupportStatus
 from roadmap.v1.lifecycle.app_streams import AppStreamImplementation
 from roadmap.v1.lifecycle.app_streams import RelevantAppStream
+from roadmap.v1.lifecycle.app_streams import StringPackage
 
 
 def test_get_app_streams(api_prefix, client):
@@ -390,3 +391,16 @@ def test_calculate_support_status_appstream(mocker, current_date, app_stream_sta
     )
 
     assert app_stream.support_status == status
+
+
+@pytest.mark.parametrize(
+    ("package", "expected"),
+    (
+        ("cairo-1.15.12-3.el8.x86_64", ("cairo", "1")),
+        ("rpm-build-libs-0:4.16.1.3-29.el9.x86_64", ("rpm-build-libs", "4")),
+    ),
+)
+def test_from_string(package, expected):
+    package = StringPackage.from_string(package)
+
+    assert (package.name, package.major) == expected


### PR DESCRIPTION
Some packages may not have a `:`. Use the partition method to avoid a ValueError and partition on `-` instead.