### PR TITLE
Drops `system-site-packages` from freeze script

### DIFF
--- a/scripts/freeze.py
+++ b/scripts/freeze.py
@@ -24,7 +24,7 @@ def freeze(python_version: str, requirement: Path) -> str:
     freeze_file = repo_root / "requirements" / f"{requirement.stem}-{python_version}.txt"
 
     # Create a fresh virtual environment
-    subprocess.check_output([python_bin, "-m", "venv", "--clear", "--system-site-packages", venv_path])
+    subprocess.check_output([python_bin, "-m", "venv", "--clear", venv_path])
     subprocess.check_output([venv_python, "-m", "pip", "install", "--upgrade", "pip"])
 
     # Install requirements with constraints


### PR DESCRIPTION
This could lead in situations where the system dependencies are added to the requirements.txt files

see https://docs.python.org/3/library/venv.html