### PR TITLE
[RSPEED-1555] App streams and RHEL have different near retirement values

### DIFF
--- a/src/roadmap/data/app_streams.py
+++ b/src/roadmap/data/app_streams.py
@@ -135,6 +135,7 @@ class AppStreamEntity(BaseModel):
             start_date=self.start_date,  # pyright: ignore [reportArgumentType]
             end_date=self.end_date,  # pyright: ignore [reportArgumentType]
             current_date=today,  # pyright: ignore [reportArgumentType]
+            months=6,
         )
 
         return self

--- a/src/roadmap/data/app_streams.py
+++ b/src/roadmap/data/app_streams.py
@@ -54,7 +54,7 @@ class AppStreamEntity(BaseModel):
     end_date: Date | None = Field(validation_alias=AliasChoices("end_date", "enddate"), default=None)
     impl: AppStreamImplementation
     initial_product_version: str | None = None
-    support_status: SupportStatus | str = SupportStatus.unknown
+    support_status: SupportStatus = SupportStatus.unknown
     os_major: int | None = None
     os_minor: int | None = None
     lifecycle: int | None = None

--- a/src/roadmap/data/app_streams.py
+++ b/src/roadmap/data/app_streams.py
@@ -54,7 +54,7 @@ class AppStreamEntity(BaseModel):
     end_date: Date | None = Field(validation_alias=AliasChoices("end_date", "enddate"), default=None)
     impl: AppStreamImplementation
     initial_product_version: str | None = None
-    support_status: SupportStatus = SupportStatus.unknown
+    support_status: SupportStatus | str = SupportStatus.unknown
     os_major: int | None = None
     os_minor: int | None = None
     lifecycle: int | None = None

--- a/src/roadmap/models.py
+++ b/src/roadmap/models.py
@@ -62,6 +62,7 @@ class Lifecycle(BaseModel):
             start_date=self.start_date,
             end_date=self.end_date,
             current_date=today,
+            months=3,
         )
 
         return self
@@ -119,7 +120,7 @@ def _calculate_support_status(
     start_date: date | None,
     end_date: date | None,
     current_date: date,
-    months: int = 3,
+    months: int,
 ) -> SupportStatus:
     support_status = SupportStatus.unknown
 

--- a/src/roadmap/models.py
+++ b/src/roadmap/models.py
@@ -25,7 +25,7 @@ class LifecycleType(StrEnum):
 
 class SupportStatus(StrEnum):
     supported = "Supported"
-    near_retirement = "Support ends within {number} months"
+    near_retirement = "Near retirement"
     retired = "Retired"
     not_installed = "Not installed"
     upcoming = "Upcoming release"
@@ -47,7 +47,7 @@ class Lifecycle(BaseModel):
     name: str
     start_date: date
     end_date: date
-    support_status: SupportStatus | str = SupportStatus.unknown
+    support_status: SupportStatus = SupportStatus.unknown
 
     @model_validator(mode="after")
     def update_support_status(self):
@@ -120,7 +120,7 @@ def _calculate_support_status(
     end_date: date | None,
     current_date: date,
     months: int = 3,
-) -> SupportStatus | str:
+) -> SupportStatus:
     support_status = SupportStatus.unknown
 
     if start_date not in (None, SupportStatus.unknown):
@@ -133,7 +133,7 @@ def _calculate_support_status(
 
         expiration_date = end_date - timedelta(days=30 * months)
         if expiration_date <= current_date:
-            return SupportStatus.near_retirement.format(number=months)
+            return SupportStatus.near_retirement
 
         return SupportStatus.supported
 

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -78,7 +78,7 @@ class RelevantAppStream(BaseModel):
     end_date: Date | None = None
     count: int
     rolling: bool = False
-    support_status: SupportStatus = SupportStatus.unknown
+    support_status: SupportStatus | str = SupportStatus.unknown
     impl: AppStreamImplementation
     systems: list[UUID]
     related: bool = False
@@ -91,6 +91,7 @@ class RelevantAppStream(BaseModel):
             start_date=self.start_date,  # pyright: ignore [reportArgumentType]
             end_date=self.end_date,  # pyright: ignore [reportArgumentType]
             current_date=today,  # pyright: ignore [reportArgumentType]
+            months=6,
         )
 
         return self

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -78,7 +78,7 @@ class RelevantAppStream(BaseModel):
     end_date: Date | None = None
     count: int
     rolling: bool = False
-    support_status: SupportStatus | str = SupportStatus.unknown
+    support_status: SupportStatus = SupportStatus.unknown
     impl: AppStreamImplementation
     systems: list[UUID]
     related: bool = False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,11 +4,32 @@ import pytest
 
 from roadmap.models import _get_rhel_display_name
 from roadmap.models import LifecycleType
+from roadmap.models import SupportStatus
 from roadmap.models import System
 from tests.utils import SUPPORT_STATUS_TEST_CASES
 
 
-@pytest.mark.parametrize(("current_date", "system_start", "system_end", "expected_status"), SUPPORT_STATUS_TEST_CASES)
+@pytest.mark.parametrize(
+    ("current_date", "system_start", "system_end", "expected_status"),
+    SUPPORT_STATUS_TEST_CASES
+    + (
+        # Support ends within 3 months (90 days)
+        (
+            date(2027, 6, 15),
+            date(2020, 1, 1),
+            date(2027, 9, 1),
+            SupportStatus.near_retirement.format(number=3),
+        ),
+        # Support ends within 6 months (180 days)
+        # The RHEL release should still be considered supported.
+        (
+            date(2027, 6, 15),
+            date(2020, 1, 1),
+            date(2027, 12, 1),
+            SupportStatus.supported,
+        ),
+    ),
+)
 def test_calculate_support_status_system(mocker, current_date, system_start, system_end, expected_status):
     # cannot mock the datetime.date.today directly as it's written in C
     # https://docs.python.org/3/library/unittest.mock-examples.html#partial-mocking

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -18,7 +18,7 @@ from tests.utils import SUPPORT_STATUS_TEST_CASES
             date(2027, 6, 15),
             date(2020, 1, 1),
             date(2027, 9, 1),
-            SupportStatus.near_retirement.format(number=3),
+            SupportStatus.near_retirement,
         ),
         # Support ends within 6 months (180 days)
         # The RHEL release should still be considered supported.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,20 +11,6 @@ SUPPORT_STATUS_TEST_CASES = (
         date(2027, 12, 31),
         SupportStatus.supported,
     ),
-    # Support ends within 6 months (180 days)
-    (
-        date(2027, 6, 15),
-        date(2020, 1, 1),
-        date(2027, 12, 1),
-        SupportStatus.supported,
-    ),
-    # Support ends within 3 months (90 days)
-    (
-        date(2027, 6, 15),
-        date(2020, 1, 1),
-        date(2027, 9, 1),
-        SupportStatus.near_retirement,
-    ),
     # Stream retired
     (
         date(2028, 1, 1),

--- a/tests/v1/lifecycle/test_app_streams.py
+++ b/tests/v1/lifecycle/test_app_streams.py
@@ -475,14 +475,14 @@ def test_app_stream_package_single_digit():
             date(2027, 6, 15),
             date(2020, 1, 1),
             date(2027, 9, 1),
-            SupportStatus.near_retirement.format(number=6),
+            SupportStatus.near_retirement,
         ),
         # Support ends within 6 months (180 days)
         (
             date(2027, 6, 15),
             date(2020, 1, 1),
             date(2027, 12, 1),
-            SupportStatus.near_retirement.format(number=6),
+            SupportStatus.near_retirement,
         ),
     ),
 )

--- a/tests/v1/lifecycle/test_app_streams.py
+++ b/tests/v1/lifecycle/test_app_streams.py
@@ -459,7 +459,32 @@ def test_app_stream_package_single_digit():
 
 
 @pytest.mark.parametrize(
-    ("current_date", "app_stream_start", "app_stream_end", "expected_status"), SUPPORT_STATUS_TEST_CASES
+    (
+        "current_date",
+        "app_stream_start",
+        "app_stream_end",
+        "expected_status",
+    ),
+    SUPPORT_STATUS_TEST_CASES
+    + (
+        # Support ends within 3 months (90 days)
+        #
+        # Since a module is considered near retirement within six months, this
+        # is also considered near retirement (3 < 6).
+        (
+            date(2027, 6, 15),
+            date(2020, 1, 1),
+            date(2027, 9, 1),
+            SupportStatus.near_retirement.format(number=6),
+        ),
+        # Support ends within 6 months (180 days)
+        (
+            date(2027, 6, 15),
+            date(2020, 1, 1),
+            date(2027, 12, 1),
+            SupportStatus.near_retirement.format(number=6),
+        ),
+    ),
 )
 def test_calculate_support_status_appstream(mocker, current_date, app_stream_start, app_stream_end, expected_status):
     # cannot mock the datetime.date.today directly as it's written in C


### PR DESCRIPTION
For RHEL only, a release is considered near retirement when the end date is within three months of the current date.

For app streams, retirement is considered within six months.

I incorrectly set the value to three months for both RHEL and app streams in #181.