### PR TITLE
[RSPEED-1528] Fully parse NEVRA from package name for more accurate matching

### DIFF
--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -380,7 +380,15 @@ def app_streams_from_packages(
     package_names_string: list[str],
     os_major: str,
 ) -> set[AppStreamKey]:
-    # ansible-core-1:2.14.17-1.el9.x86_64
+    # FIXME: This approach to getting the stream from the package NEVRA is incorrect and flawed.
+    #
+    #        The package major/minor are not guaranteed to match the stream major/minor.
+    #        That it matches is a coincidence, one that happens pretty often, giving the illusion
+    #        the code is working as intended.
+    #
+    #        In order to accurately lookup the app stream from a package NEVRA string, we need to
+    #        compile a list of all the versions — at least major/minor — that are in an app stream.
+    #        That data does not exist today in readily available format.
     packages = set(NEVRA.from_string(package) for package in package_names_string)
     app_streams = set()
     for package in packages:

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -325,29 +325,38 @@ class NEVRA(BaseModel, frozen=True):
 
     @classmethod
     def from_string(cls, package: str) -> "NEVRA":
-        # name-[epoch:]version-release.architecture
-        #
-        # ansible-core-1:2.14.17-1.el9.x86_64
-        # NetworkManager-1:1.46.0-26.el9_4.x86_64
-        # basesystem-0:11-13.el9.noarch
-        # abattis-cantarell-fonts-0:0.301-4.el9.noarch
-        #
+        """Parse a package string and return an instance of this class.
+
+        The expected string format is name-[epoch:]version-release.architecture.
+
+        Examples:
+
+            cairo-1.15.12-3.el8.x86_64
+            ansible-core-1:2.14.17-1.el9.x86_64
+            NetworkManager-1:1.46.0-26.el9_4.x86_64
+            basesystem-0:11-13.el9.noarch
+            abattis-cantarell-fonts-0:0.301-4.el9.noarch
+
+        """
+
         # Partition into name and version/release/architecture
         name, sep, vra = package.partition(":")
         if sep:
             name, epoch = name.rsplit("-", 1)
         else:
-            # Missing epoch component, ':' Partition on '-' instead.
-            #   Example: cairo-1.15.12-3.el8.x86_64
+            # Missing epoch component. Partition on '-' instead.
+            # Example: cairo-1.15.12-3.el8.x86_64
             epoch = "0"
             name, _, vra = package.partition("-")
 
+        # Extract architecture and release
         arch_idx = vra.rindex(".")
         arch = vra[arch_idx + 1 :]
 
         rel_idx = vra.index("-", 0, arch_idx)
         release = vra[rel_idx + 1 : arch_idx]
 
+        # Get the version then split in into X.Y.Z parts
         version = vra[:rel_idx]
         major, _, minor_z = version.partition(".")
         if not minor_z:

--- a/tests/v1/lifecycle/test_app_streams.py
+++ b/tests/v1/lifecycle/test_app_streams.py
@@ -512,15 +512,26 @@ def test_calculate_support_status_appstream(mocker, current_date, app_stream_sta
 @pytest.mark.parametrize(
     ("package", "expected"),
     (
-        ("cairo-1.15.12-3.el8.x86_64", ("cairo", "1", "15")),
-        ("rpm-build-libs-0:4.16.1.3-29.el9.x86_64", ("rpm-build-libs", "4", "16")),
-        ("ansible-core-1:2.14.17-1.el9.x86_64", ("ansible-core", "2", "14")),
-        ("NetworkManager-1:1.46.0-26.el9_4.x86_64", ("NetworkManager", "1", "46")),
-        ("basesystem-0:11-13.el9.noarch", ("basesystem", "11", "")),
-        ("abattis-cantarell-fonts-0:0.301-4.el9.noarch", ("abattis-cantarell-fonts", "0", "301")),
+        ("cairo-1.15.12-3.el8.x86_64", ("cairo", "0", "1", "15", "12", "3.el8", "x86_64")),
+        ("rpm-build-libs-0:4.16.1.3-29.el9.x86_64", ("rpm-build-libs", "0", "4", "16", "1.3", "29.el9", "x86_64")),
+        ("ansible-core-1:2.14.17-1.el9.x86_64", ("ansible-core", "1", "2", "14", "17", "1.el9", "x86_64")),
+        ("NetworkManager-1:1.46.0-26.el9_4.x86_64", ("NetworkManager", "1", "1", "46", "0", "26.el9_4", "x86_64")),
+        ("basesystem-0:11-13.el9.noarch", ("basesystem", "0", "11", "", "", "13.el9", "noarch")),
+        (
+            "abattis-cantarell-fonts-0:0.301-4.el9.noarch",
+            ("abattis-cantarell-fonts", "0", "0", "301", "", "4.el9", "noarch"),
+        ),
     ),
 )
 def test_from_string(package, expected):
     package = NEVRA.from_string(package)
 
-    assert (package.name, package.major, package.minor) == expected
+    assert (
+        package.name,
+        package.epoch,
+        package.major,
+        package.minor,
+        package.z,
+        package.release,
+        package.arch,
+    ) == expected

--- a/tests/v1/lifecycle/test_app_streams.py
+++ b/tests/v1/lifecycle/test_app_streams.py
@@ -11,8 +11,8 @@ from roadmap.config import Settings
 from roadmap.data.app_streams import AppStreamEntity
 from roadmap.models import SupportStatus
 from roadmap.v1.lifecycle.app_streams import AppStreamImplementation
+from roadmap.v1.lifecycle.app_streams import NEVRA
 from roadmap.v1.lifecycle.app_streams import RelevantAppStream
-from roadmap.v1.lifecycle.app_streams import StringPackage
 from tests.utils import SUPPORT_STATUS_TEST_CASES
 
 
@@ -512,11 +512,15 @@ def test_calculate_support_status_appstream(mocker, current_date, app_stream_sta
 @pytest.mark.parametrize(
     ("package", "expected"),
     (
-        ("cairo-1.15.12-3.el8.x86_64", ("cairo", "1")),
-        ("rpm-build-libs-0:4.16.1.3-29.el9.x86_64", ("rpm-build-libs", "4")),
+        ("cairo-1.15.12-3.el8.x86_64", ("cairo", "1", "15")),
+        ("rpm-build-libs-0:4.16.1.3-29.el9.x86_64", ("rpm-build-libs", "4", "16")),
+        ("ansible-core-1:2.14.17-1.el9.x86_64", ("ansible-core", "2", "14")),
+        ("NetworkManager-1:1.46.0-26.el9_4.x86_64", ("NetworkManager", "1", "46")),
+        ("basesystem-0:11-13.el9.noarch", ("basesystem", "11", "")),
+        ("abattis-cantarell-fonts-0:0.301-4.el9.noarch", ("abattis-cantarell-fonts", "0", "301")),
     ),
 )
 def test_from_string(package, expected):
-    package = StringPackage.from_string(package)
+    package = NEVRA.from_string(package)
 
-    assert (package.name, package.major) == expected
+    assert (package.name, package.major, package.minor) == expected


### PR DESCRIPTION
Since we are only comparing the package major version, we are picking up a lot of erroneous package entries. Compare using the major and minor version in order to provide accurate results.

While fixing this and looking at the approach to matching a package to an app stream module, I figured out the whole approach is flawed. This does fix the immediate issue but the strategy we are taking to match packages to modules needs to be changed.