### PR TITLE
[RSPEED-1520] Correct app stream end dates for rolling

### DIFF
--- a/src/roadmap/data/app_streams.py
+++ b/src/roadmap/data/app_streams.py
@@ -85,10 +85,6 @@ class AppStreamEntity(BaseModel):
 
     @model_validator(mode="after")
     def set_os_version(self):
-        # Change this to be
-        # if initial_product_version is not None
-        #   then set os_major/minor
-        # Don't override the values if they were set
         if self.initial_product_version is not None:
             self.os_major = int(self.initial_product_version.split(".")[0])
             try:

--- a/src/roadmap/v1/lifecycle/rhel.py
+++ b/src/roadmap/v1/lifecycle/rhel.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import Path
 from pydantic import BaseModel
+from pydantic import model_validator
 
 from roadmap.common import decode_header
 from roadmap.common import get_lifecycle_type
@@ -41,6 +42,13 @@ class RelevantSystemsResponse(BaseModel):
 
 class LifecycleResponse(BaseModel):
     data: list[RHELLifecycle]
+
+    @model_validator(mode="after")
+    def validate(self):
+        # Run model validation in order to ensure the support status is accurate.
+        self.data = [n.model_validate(n) for n in self.data]
+
+        return self
 
 
 def get_lifecycle_data(

--- a/tests/v1/lifecycle/test_app_streams.py
+++ b/tests/v1/lifecycle/test_app_streams.py
@@ -19,9 +19,11 @@ from tests.utils import SUPPORT_STATUS_TEST_CASES
 def test_get_app_streams(api_prefix, client):
     result = client.get(f"{api_prefix}/lifecycle/app-streams")
     data = result.json().get("data", [])
+    end_dates = {n["end_date"] for n in data}
 
     assert result.status_code == 200
     assert len(data) > 0
+    assert "1111-11-11" not in end_dates
 
 
 def test_get_app_streams_filter(api_prefix, client):


### PR DESCRIPTION
Set end_date for app streams and update the support status during response.

For RHEL lifecycle, update support status during response.