### PR TITLE
[RSPEED-1095] Add tests for relevant APIs

### DIFF
--- a/scripts/load_host_data.py
+++ b/scripts/load_host_data.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from datetime import timedelta
 from pathlib import Path
 from time import sleep
-from uuid import uuid4
 
 from app_common_python import json
 from app_common_python import os
@@ -104,8 +103,8 @@ def main():
 
     # Build the records
     records = []
-    for n in range(len(host_data)):
-        id = uuid4()
+    for host in host_data:
+        id = host["id"]
         init_date = fake.date_time_between(start_date="-1w")
 
         records.append(
@@ -114,13 +113,13 @@ def main():
                 display_name=fake.unique.hostname(),
                 created_on=init_date,
                 modified_on=init_date,
-                system_profile_facts=host_data[n].get("system_profile_facts", {}),
+                system_profile_facts=host.get("system_profile_facts", {}),
                 ansible_host="ansible_host",
                 stale_timestamp=init_date + timedelta(30),
                 reporter="toast loader",
                 per_reporter_staleness={},
                 org_id="1234",
-                groups=host_data[n].get("groups", []),
+                groups=host.get("groups", []),
                 tags_alt=[],
                 last_check_in=datetime.now(),
             )

--- a/tests/v1/lifecycle/test_app_streams.py
+++ b/tests/v1/lifecycle/test_app_streams.py
@@ -108,9 +108,12 @@ def test_get_relevant_app_stream(api_prefix, client):
     client.app.dependency_overrides[decode_header] = decode_header_override
     result = client.get(f"{api_prefix}/relevant/lifecycle/app-streams")
     data = result.json().get("data", "")
+    display_names = {item["display_name"] for item in data}
 
     assert result.status_code == 200
     assert len(data) > 0
+    assert display_names.issuperset(["Redis 5", "Redis 6"]), "Missing expected modules in response"
+    assert not any(item["rolling"] for item in data), "Rolling app streams should not be in the response"
 
 
 def test_get_relevant_app_stream_error(api_prefix, client, mocker):

--- a/tests/v1/lifecycle/test_rhel.py
+++ b/tests/v1/lifecycle/test_rhel.py
@@ -65,7 +65,7 @@ def test_rhel_lifecycle_full_major(client, api_prefix, os_major):
     assert minor_versions == {None}
 
 
-def test_rhel_relevant(client, api_prefix):
+def test_rhel_relevant(client, api_prefix, ids_by_os):
     async def query_rbac_override():
         return [
             {
@@ -83,11 +83,16 @@ def test_rhel_relevant(client, api_prefix):
 
     response = client.get(f"{api_prefix}/relevant/lifecycle/rhel")
     data = response.json()["data"]
+    rhel_9_1_mainline = [
+        item for item in data if (9, 1, "mainline") == (item["major"], item["minor"], item["lifecycle_type"])
+    ]
+    rhel_9_1_mainline = set(rhel_9_1_mainline[0]["systems"])
 
     assert len(data) > 1
     assert data[0].keys() == System.model_fields.keys()
-    assert len(data[0]["systems"]) > 0  # There should be system IDs
-    assert uuid.UUID(data[0]["systems"][0])  # The system ID should be a valid UUID
+    assert len(data[0]["systems"]) > 0, "There should be system IDs"
+    assert uuid.UUID(data[0]["systems"][0]), "The system ID should be a valid UUID"
+    assert rhel_9_1_mainline == ids_by_os["9.1"]
     for item in data:
         assert item["count"] == len(item["systems"]), "Mismatch between count and number of system IDs"
 


### PR DESCRIPTION
Get the system IDs by OS version from the test data in order to verify the correct system IDs are returned. I initially was comparing _all_ the system IDs by os version but we have some systems with different lifecycles, so that complicated things. The current tests assert a list of system IDs for one OS version.