### PR TITLE
[RSPEED-1649] Set correct end date for EUS systems

### DIFF
--- a/src/roadmap/v1/lifecycle/rhel.py
+++ b/src/roadmap/v1/lifecycle/rhel.py
@@ -200,6 +200,9 @@ async def get_relevant_systems(  # noqa: C901
             if count_key.lifecycle == LifecycleType.e4s:
                 end_date = lifecycle_info.end_date_e4s
 
+            if count_key.lifecycle == LifecycleType.eus:
+                end_date = lifecycle_info.end_date_eus
+
         results.append(
             System(
                 name=count_key.name,


### PR DESCRIPTION
This was a bug by omission. I added a test case to verify the end dates for all lifecycle types are correct.