### PR TITLE
Rollback coverity check to 0.2

### DIFF
--- a/.tekton/pipeline-build.yaml
+++ b/.tekton/pipeline-build.yaml
@@ -511,7 +511,7 @@ spec:
             value: sast-coverity-check-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:dda889f85faa30eb18db4f195bc03428e8913afa14624552d2cb9f714c786dbf
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:7c845b10d257b874f645ea30deeff3c1ce2b38e7b6e331564f32c8684f41b520
 
           - name: kind
             value: task

--- a/.tekton/pipeline-build.yaml
+++ b/.tekton/pipeline-build.yaml
@@ -511,7 +511,7 @@ spec:
             value: sast-coverity-check-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:7c845b10d257b874f645ea30deeff3c1ce2b38e7b6e331564f32c8684f41b520
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:00c6330a08fb765ec4784aba5378afc9f09b1f6f8cac64de31a7ab27bc308bdd
 
           - name: kind
             value: task


### PR DESCRIPTION
The 0.3 version was working on Friday, but it started failing today. Neither of the 0.3 versions are working but the latest 0.2 version seems to work reliably.