### PR TITLE
[RSPEED-1674] Ensure related system IDs are unique

### DIFF
--- a/src/roadmap/models.py
+++ b/src/roadmap/models.py
@@ -78,7 +78,7 @@ class System(Lifecycle):
     count: int = 0
     lifecycle_type: LifecycleType
     related: bool = False
-    systems: list[UUID] = []
+    systems: set[UUID] = set()
 
     @model_validator(mode="after")
     def set_display_name(self):

--- a/src/roadmap/v1/lifecycle/rhel.py
+++ b/src/roadmap/v1/lifecycle/rhel.py
@@ -146,7 +146,7 @@ async def get_relevant_systems(  # noqa: C901
 ) -> RelevantSystemsResponse:
     system_counts = defaultdict(int)
     missing = defaultdict(int)
-    systems_by_version_lifecycle = defaultdict(list)
+    systems_by_version_lifecycle = defaultdict(set)
     async for result in systems.mappings():
         # Make sure we have a system profile with enough data, otherwise continue
         if not (system_profile := result.get("system_profile_facts")):
@@ -173,7 +173,7 @@ async def get_relevant_systems(  # noqa: C901
         # Collect system IDs by major version, minor version, and lifecycle type so we can return those in the response
         system_id = result["id"]
         system_id_key = (str(os_major) if os_minor is None else f"{os_major}.{os_minor}", lifecycle_type)
-        systems_by_version_lifecycle[system_id_key].append(system_id)
+        systems_by_version_lifecycle[system_id_key].add(system_id)
 
         count_key = HostCount(name=name, major=os_major, minor=os_minor, lifecycle=lifecycle_type)
         system_counts[count_key] += 1

--- a/tests/v1/lifecycle/test_app_streams.py
+++ b/tests/v1/lifecycle/test_app_streams.py
@@ -114,6 +114,9 @@ def test_get_relevant_app_stream(api_prefix, client):
     assert len(data) > 0
     assert display_names.issuperset(["Redis 5", "Redis 6"]), "Missing expected modules in response"
     assert not any(item["rolling"] for item in data), "Rolling app streams should not be in the response"
+    assert all([len(set(item["systems"])) == len(item["systems"]) for item in data]), (
+        "Found duplicate system IDs in results"
+    )
 
 
 def test_get_relevant_app_stream_error(api_prefix, client, mocker):
@@ -504,7 +507,6 @@ def test_calculate_support_status_appstream(mocker, current_date, app_stream_sta
         os_major=1,
         os_minor=1,
         count=4,
-        impl=AppStreamImplementation.package,
         rolling=False,
         start_date=app_stream_start,
         end_date=app_stream_end,

--- a/tests/v1/lifecycle/test_rhel.py
+++ b/tests/v1/lifecycle/test_rhel.py
@@ -161,3 +161,6 @@ def test_rhel_relevant_related(client, api_prefix):
 
     assert len(data) > 1
     assert len(related_hosts) > 1
+    assert all([len(set(item["systems"])) == len(item["systems"]) for item in data]), (
+        "Found duplicate system IDs in results"
+    )


### PR DESCRIPTION
Gather system IDs into a `set` to ensure the values are unique.