### PR TITLE
Update konflux references

### DIFF
--- a/.tekton/pipeline-build.yaml
+++ b/.tekton/pipeline-build.yaml
@@ -511,7 +511,7 @@ spec:
             value: sast-coverity-check-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:00c6330a08fb765ec4784aba5378afc9f09b1f6f8cac64de31a7ab27bc308bdd
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:dda889f85faa30eb18db4f195bc03428e8913afa14624552d2cb9f714c786dbf
 
           - name: kind
             value: task

--- a/.tekton/pipeline-build.yaml
+++ b/.tekton/pipeline-build.yaml
@@ -141,7 +141,7 @@ spec:
             value: git-clone-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:0e512b12775b2bcc4eb47bb34b7a2db2e91c3ceef04b2f2487fa421032d8859a
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d35e5d501cb5f5f88369511f76249857cb5ac30250e1dcf086939321964ff6b9
 
           - name: kind
             value: task
@@ -180,7 +180,7 @@ spec:
             value: prefetch-dependencies-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:d0cbc492da865be336d09926eb6e3494403dccaa4a212bbdf472d8adbf80ab08
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:5e15408f997557153b13d492aeccb51c01923bfbe4fbdf6f1e8695ce1b82f826
 
           - name: kind
             value: task
@@ -238,7 +238,7 @@ spec:
             value: buildah-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:d90c4cf682189faab5c702e55f4855242e228ce1a05e54e1734b7b9c6fa40441
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:65864bd7623b8819707ffc0949c390152f99f24308803e773000009f71ed2d6b
 
           - name: kind
             value: task
@@ -277,7 +277,7 @@ spec:
             value: build-image-index
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:3cf3dcc0bf7b674b940063b4d55e41fe7d43636a1d82572e3850228aa5350fa8
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:846dc9975914f31380ec2712fdbac9df3b06c00a9cc7df678315a7f97145efc2
 
           - name: kind
             value: task
@@ -305,7 +305,7 @@ spec:
             value: deprecated-image-check
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:270a79138a98e43c366d3722978cb5940d2bcb822ba6b60377330f863b7a1e62
+            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:3c8b81fa868e27c6266e7660a4bfb4c822846dcf4304606e71e20893b0d3e515
 
           - name: kind
             value: task
@@ -359,7 +359,7 @@ spec:
             value: ecosystem-cert-preflight-checks
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:95ca11d147ee97d98f495477e9f42afe94ba3f869fc81c4e7b241ebd21e7395f
+            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b550ff4f0b634512ce5200074be7afd7a5a6c05b783620c626e2a3035cd56448
 
           - name: kind
             value: task
@@ -551,7 +551,7 @@ spec:
             value: sast-shell-check-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:1e8f18f892e16f5d0fc0f42ae8512e3c78251d43cd9d9f7cfd3f6667242bf619
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:808bcaf75271db6a999f53fdefb973a385add94a277d37fbd3df68f8ac7dfaa3
 
           - name: kind
             value: task
@@ -693,7 +693,7 @@ spec:
             value: show-sbom
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:002f7c8c1d2f9e09904035da414aba1188ae091df0ea9532cd997be05e73d594
+            value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:1b1df4da95966d08ac6a5b8198710e09e68b5c2cdc707c37d9d19769e65884b2
 
           - name: kind
             value: task


### PR DESCRIPTION
I had failures with the two latest `sast-coverity-check` images, so I'm using a slightly older 0.3 image. The task failures _seem_ to be a problem with `microdnf` but it's unclean why it's only in the `sast-coverity-check` task that it's a problem. `microdnf` seems to work just fine when building the image outside of coverity.

```
quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:
    quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:f81ade665c725616b918356c8c2fb2d4ed972e822a1a3181933cd0ada728a231  Fri, 27 Jun 2025 14:51:04 -0000
    quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:34ac8e9ddfaafedaa61a7c3c95d86e674556bfe3da488d94c3bf28fff9875b38  Thu, 26 Jun 2025 08:51:34 -0000
    quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:dda889f85faa30eb18db4f195bc03428e8913afa14624552d2cb9f714c786dbf  Wed, 18 Jun 2025 12:00:04 -0000
    quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:7c845b10d257b874f645ea30deeff3c1ce2b38e7b6e331564f32c8684f41b520  Wed, 04 Jun 2025 07:24:00 -0000
    quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:2717404c60ce2e875bf2583a15f7cc959ef53236d260aa4c2f193dea141d4a35  Fri, 27 Jun 2025 14:51:00 -0000
    quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:316fa52a749f717fd2d73e65504e1c96eaa35ddbb628771251ea7dded3f934ac  Thu, 26 Jun 2025 08:51:31 -0000
    quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:00c6330a08fb765ec4784aba5378afc9f09b1f6f8cac64de31a7ab27bc308bdd  Wed, 18 Jun 2025 11:59:59 -0000
    quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:2d351b416c29b1f14f8e20cccab9c991f2f0c1ea0c3ef9b67299ecf0917b7887  Fri, 09 May 2025 14:06:07 -0000
    quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.1@sha256:8512638968ebe77b335ef22442e32eaa0ebddb5854993c43becefc68e4ad411c  Fri, 27 Jun 2025 14:50:56 -0000
    quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.1@sha256:edefb7bda1ebe76e10a795e5915e5265092f7f9c44cc3506c25869f261ea45dd  Thu, 19 Jun 2025 12:58:37 -0000
    quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.1@sha256:664e69cea76fdd1db6aa479f33b68c12814dbc05668f4dd0337948e1e70f24b8  Wed, 18 Jun 2025 11:59:56 -0000
    quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.1@sha256:1b9c99881f9101e055798249c580eb7ccf7d24d0f55e940a1e71678546543260  Wed, 04 Jun 2025 07:23:55 -0000
```

It looks like [this bug in librepo](https://gitlab.com/redhat/centos-stream/rpms/librepo/-/merge_requests/23/diffs) is what is causing failures.