### PR TITLE
[RSPEED-1515] Change how package data are grouped

### DIFF
--- a/scripts/load_host_data.py
+++ b/scripts/load_host_data.py
@@ -13,12 +13,12 @@ from app_common_python import os
 from faker import Faker
 from sqlalchemy import create_engine
 from sqlalchemy import delete
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.ddl import CreateSchema
-from sqlalchemy.types import JSON
 from sqlalchemy.types import String
 from sqlalchemy.types import TIMESTAMP
 from sqlalchemy.types import UUID
@@ -38,17 +38,17 @@ class Host(HBI):
     display_name: Mapped[str] = mapped_column(String(200))
     created_on: Mapped[TIMESTAMP] = mapped_column(TIMESTAMP())
     modified_on: Mapped[TIMESTAMP] = mapped_column(TIMESTAMP())
-    facts: Mapped[JSON] = mapped_column(JSON(), nullable=True, default={})
-    tags: Mapped[JSON] = mapped_column(JSON(), nullable=True, default={})
-    canonical_facts: Mapped[JSON] = mapped_column(JSON(), nullable=True, default={})
-    system_profile_facts: Mapped[JSON] = mapped_column(JSON(), nullable=True, default={})
+    facts: Mapped[JSONB] = mapped_column(JSONB(), nullable=True, default={})
+    tags: Mapped[JSONB] = mapped_column(JSONB(), nullable=True, default={})
+    canonical_facts: Mapped[JSONB] = mapped_column(JSONB(), nullable=True, default={})
+    system_profile_facts: Mapped[JSONB] = mapped_column(JSONB(), nullable=True, default={})
     ansible_host: Mapped[str] = mapped_column(String(255))
     stale_timestamp: Mapped[TIMESTAMP] = mapped_column(TIMESTAMP())
     reporter: Mapped[str] = mapped_column(String(255))
-    per_reporter_staleness: Mapped[JSON] = mapped_column(JSON(), default={})
+    per_reporter_staleness: Mapped[JSONB] = mapped_column(JSONB(), default={})
     org_id: Mapped[str] = mapped_column(String(36))
-    groups: Mapped[JSON] = mapped_column(JSON(), default=[])
-    tags_alt: Mapped[JSON] = mapped_column(JSON(), nullable=True, default=[{}])
+    groups: Mapped[JSONB] = mapped_column(JSONB(), default=[])
+    tags_alt: Mapped[JSONB] = mapped_column(JSONB(), nullable=True, default=[{}])
     last_check_in: Mapped[TIMESTAMP] = mapped_column(TIMESTAMP())
 
 

--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -189,7 +189,7 @@ async def query_host_inventory(
         org_id = "1234"
 
     # Build up a query for this org's hosts.
-    query = "SELECT * FROM hbi.hosts WHERE org_id = :org_id"
+    query = "SELECT id, system_profile_facts FROM hbi.hosts WHERE org_id = :org_id"
 
     # #>> '{{operating_system,major}}' fetches the attribute "major" from the
     # "operating_system" subobject in the host's record. This subobject is kept

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -261,7 +261,7 @@ async def systems_by_app_stream(
     missing = defaultdict(int)
     systems_by_stream = defaultdict(set)
     module_cache = {}
-    package_data = set()
+    package_data = defaultdict(list)
     module_app_streams = set()
     async for system in systems.mappings():
         if not (system_profile := system.get("system_profile_facts")):
@@ -287,16 +287,19 @@ async def systems_by_app_stream(
         # Store package name, os_major, and system ID for later processing outside the loop.
         # This substantially reduces the time it takes for this function to return.
         system_id = system["id"]
-        package_data = set((package, os_major, system_id) for package in system_profile.get("installed_packages", []))
+        for package in system_profile.get("installed_packages", []):
+            package_data[(package, os_major)].append(system_id)
 
         module_app_streams = app_streams_from_modules(dnf_modules, os_major, module_cache)
         for app_stream in module_app_streams:
             systems_by_stream[app_stream].add(system_id)
 
     # Now process the packages outside of the host record loop
-    for package, os_major, system_id in package_data:
+    for args, system_ids in package_data.items():
+        package, os_major = args
+        # for package, os_major in args:
         if app_stream := app_stream_from_package(package, os_major):
-            systems_by_stream[app_stream].add(system_id)
+            systems_by_stream[app_stream].update(system_ids)
 
     if missing:
         missing_items = ", ".join(f"{key}: {value}" for key, value in missing.items())


### PR DESCRIPTION
The goal of using a set initially was to keep the number package items that needed to be processed to a minimu. But when system_id was added to the mix, it remove any possibility of deduplicating across systems. Furthermore, this seems to have introduced a bug that causes inconsistent matching of packages to hosts.

Change the grouping strategy to collect system IDs into groups based on the package and its major OS version. I think that gets close to the original goal while still helping improve performance.

I changed the schema of the local hosts table used for development and testing to JSONB fields which matches the production hosts database. Once this change merges, run the following to recreate the host table.
```
make stop-db start-db load-host-data
```