### PR TITLE
[RSPEED-1728] Extend default OpenAPI spec to include API security

### DIFF
--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -405,8 +405,7 @@ def extend_openapi(app: FastAPI):
             }
         }
         # Set the default API security scheme
-        schema["security"] = {}
-        schema["security"]["Authorization"] = []
+        schema["security"] = [{"Authorization": []}]
 
         app.openapi_schema = schema
         return app.openapi_schema

--- a/src/roadmap/main.py
+++ b/src/roadmap/main.py
@@ -11,6 +11,7 @@ from sentry_sdk.integrations.starlette import StarletteIntegration
 
 import roadmap.v1
 
+from roadmap.common import extend_openapi
 from roadmap.common import HealthCheckFilter
 
 
@@ -39,6 +40,7 @@ app = FastAPI(
     summary="Major RHEL roadmap items as well as lifecycle data for RHEL and app streams.",
     redirect_slashes=False,
 )
+app.openapi = extend_openapi(app)
 
 # Add Prometheus metrics
 instrumentor = Instrumentator()


### PR DESCRIPTION
Add scheme and apply it by default to all APIs. This should add authorization settings to the examples in the API documentation.

https://learn.openapis.org/specification/security.html