### PR TITLE
[RSPEED-1730] Update `librepo` to fix intermittent build failure

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,7 +20,12 @@ ENV PYTHON_VERSION="3.12"
 
 # Temporary workaround until new version of librepo is available in base image
 # https://github.com/rpm-software-management/librepo/pull/325
-RUN rpm -Uvh https://gitlab.cee.redhat.com/rhel-lightspeed/roadmap/artifacts/-/raw/main/rpm/librepo-1.18.0-5.el10.x86_64.rpm
+RUN curl \
+    --insecure \
+    --fail \
+    --output /tmp/librepo-1.18.0-5.el10.x86_64.rpm \
+    https://gitlab.cee.redhat.com/rhel-lightspeed/roadmap/artifacts/-/raw/main/rpm/librepo-1.18.0-5.el10.x86_64.rpm \
+    && rpm -Uvh /tmp/librepo-1.18.0-5.el10.x86_64.rpm
 
 RUN microdnf install -y --nodocs \
     gcc \
@@ -53,7 +58,12 @@ COPY --from=builder /opt/venvs/ /opt/venvs/
 
 # Temporary workaround until new version of librepo is available in base image
 # https://github.com/rpm-software-management/librepo/pull/325
-RUN rpm -Uvh https://gitlab.cee.redhat.com/rhel-lightspeed/roadmap/artifacts/-/raw/main/rpm/librepo-1.18.0-5.el10.x86_64.rpm
+RUN curl \
+    --insecure \
+    --fail \
+    --output /tmp/librepo-1.18.0-5.el10.x86_64.rpm \
+    https://gitlab.cee.redhat.com/rhel-lightspeed/roadmap/artifacts/-/raw/main/rpm/librepo-1.18.0-5.el10.x86_64.rpm \
+    && rpm -Uvh /tmp/librepo-1.18.0-5.el10.x86_64.rpm
 
 RUN microdnf install -y --nodocs \
     libpq \

--- a/Containerfile
+++ b/Containerfile
@@ -23,9 +23,9 @@ ENV PYTHON_VERSION="3.12"
 RUN curl \
     --insecure \
     --fail \
-    --output /tmp/librepo-1.18.0-5.el10.x86_64.rpm \
+    --silent \
     https://gitlab.cee.redhat.com/rhel-lightspeed/roadmap/artifacts/-/raw/main/rpm/librepo-1.18.0-5.el10.x86_64.rpm \
-    && rpm -Uvh /tmp/librepo-1.18.0-5.el10.x86_64.rpm
+    | rpm -Uvh -
 
 RUN microdnf install -y --nodocs \
     gcc \
@@ -61,10 +61,9 @@ COPY --from=builder /opt/venvs/ /opt/venvs/
 RUN curl \
     --insecure \
     --fail \
-    --output /tmp/librepo-1.18.0-5.el10.x86_64.rpm \
+    --silent \
     https://gitlab.cee.redhat.com/rhel-lightspeed/roadmap/artifacts/-/raw/main/rpm/librepo-1.18.0-5.el10.x86_64.rpm \
-    && rpm -Uvh /tmp/librepo-1.18.0-5.el10.x86_64.rpm
-
+    | rpm -Uvh -
 RUN microdnf install -y --nodocs \
     libpq \
     "python${PYTHON_VERSION}" \

--- a/Containerfile
+++ b/Containerfile
@@ -18,6 +18,10 @@ ENV PYTHON="${VENV}/bin/python"
 ENV PATH="${VENV}/bin:$PATH"
 ENV PYTHON_VERSION="3.12"
 
+# Temporary workaround until new version of librepo is available in base image
+# https://github.com/rpm-software-management/librepo/pull/325
+RUN rpm -Uvh https://gitlab.cee.redhat.com/rhel-lightspeed/roadmap/artifacts/-/raw/main/rpm/librepo-1.18.0-5.el10.x86_64.rpm
+
 RUN microdnf install -y --nodocs \
     gcc \
     libpq-devel \
@@ -46,6 +50,10 @@ ENV PYTHONPATH=/srv/roady/
 
 COPY LICENSE /licenses/Apache-2.0.txt
 COPY --from=builder /opt/venvs/ /opt/venvs/
+
+# Temporary workaround until new version of librepo is available in base image
+# https://github.com/rpm-software-management/librepo/pull/325
+RUN rpm -Uvh https://gitlab.cee.redhat.com/rhel-lightspeed/roadmap/artifacts/-/raw/main/rpm/librepo-1.18.0-5.el10.x86_64.rpm
 
 RUN microdnf install -y --nodocs \
     libpq \

--- a/Containerfile
+++ b/Containerfile
@@ -24,8 +24,10 @@ RUN curl \
     --insecure \
     --fail \
     --silent \
+    --output /tmp/librepo-1.18.0-5.el10.x86_64.rpm \
     https://gitlab.cee.redhat.com/rhel-lightspeed/roadmap/artifacts/-/raw/main/rpm/librepo-1.18.0-5.el10.x86_64.rpm \
-    | rpm -Uvh -
+    && rpm -Uvh /tmp/librepo-1.18.0-5.el10.x86_64.rpm \
+    && rm -f /tmp/librepo-1.18.0-5.el10.x86_64.rpm
 
 RUN microdnf install -y --nodocs \
     gcc \
@@ -62,8 +64,11 @@ RUN curl \
     --insecure \
     --fail \
     --silent \
+    --output /tmp/librepo-1.18.0-5.el10.x86_64.rpm \
     https://gitlab.cee.redhat.com/rhel-lightspeed/roadmap/artifacts/-/raw/main/rpm/librepo-1.18.0-5.el10.x86_64.rpm \
-    | rpm -Uvh -
+    && rpm -Uvh /tmp/librepo-1.18.0-5.el10.x86_64.rpm \
+    && rm -f /tmp/librepo-1.18.0-5.el10.x86_64.rpm
+
 RUN microdnf install -y --nodocs \
     libpq \
     "python${PYTHON_VERSION}" \


### PR DESCRIPTION
There are no publicly available rpms of `librepo-1.18.0-5` yet so I had to store it somewhere that could be accessed during the build process.

https://github.com/rpm-software-management/librepo/pull/325