### PR TITLE
Remove librepo workaround and pin base image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10-minimal:latest AS builder
+FROM registry.access.redhat.com/ubi10-minimal:10.0-1751880071 AS builder
 
 LABEL com.redhat.component=rhel-roadmap-api
 LABEL description="Red Hat Enterprise Linux Roadmap API"
@@ -18,17 +18,6 @@ ENV PYTHON="${VENV}/bin/python"
 ENV PATH="${VENV}/bin:$PATH"
 ENV PYTHON_VERSION="3.12"
 
-# Temporary workaround until new version of librepo is available in base image
-# https://github.com/rpm-software-management/librepo/pull/325
-RUN curl \
-    --insecure \
-    --fail \
-    --silent \
-    --output /tmp/librepo-1.18.0-5.el10.x86_64.rpm \
-    https://gitlab.cee.redhat.com/rhel-lightspeed/roadmap/artifacts/-/raw/main/rpm/librepo-1.18.0-5.el10.x86_64.rpm \
-    && rpm -Uvh /tmp/librepo-1.18.0-5.el10.x86_64.rpm \
-    && rm -f /tmp/librepo-1.18.0-5.el10.x86_64.rpm
-
 RUN microdnf install -y --nodocs \
     gcc \
     libpq-devel \
@@ -47,7 +36,7 @@ RUN "python${PYTHON_VERSION}" -m venv "$VENV" \
     && /opt/venvs/replication/bin/python -m pip install --no-cache-dir --requirement /usr/share/container-setup/requirements-replication.txt
 
 
-FROM registry.access.redhat.com/ubi10-minimal:latest AS final
+FROM registry.access.redhat.com/ubi10-minimal:10.0-1751880071 AS final
 
 ENV VENV=/opt/venvs/roadmap
 ENV PYTHON="${VENV}/bin/python"
@@ -57,17 +46,6 @@ ENV PYTHONPATH=/srv/roady/
 
 COPY LICENSE /licenses/Apache-2.0.txt
 COPY --from=builder /opt/venvs/ /opt/venvs/
-
-# Temporary workaround until new version of librepo is available in base image
-# https://github.com/rpm-software-management/librepo/pull/325
-RUN curl \
-    --insecure \
-    --fail \
-    --silent \
-    --output /tmp/librepo-1.18.0-5.el10.x86_64.rpm \
-    https://gitlab.cee.redhat.com/rhel-lightspeed/roadmap/artifacts/-/raw/main/rpm/librepo-1.18.0-5.el10.x86_64.rpm \
-    && rpm -Uvh /tmp/librepo-1.18.0-5.el10.x86_64.rpm \
-    && rm -f /tmp/librepo-1.18.0-5.el10.x86_64.rpm
 
 RUN microdnf install -y --nodocs \
     libpq \

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi10-minimal:10.0-1751880071 AS builder
+FROM registry.access.redhat.com/ubi10-minimal:10.0-1751880071 AS base
+
+FROM base AS builder
 
 LABEL com.redhat.component=rhel-roadmap-api
 LABEL description="Red Hat Enterprise Linux Roadmap API"
@@ -36,7 +38,7 @@ RUN "python${PYTHON_VERSION}" -m venv "$VENV" \
     && /opt/venvs/replication/bin/python -m pip install --no-cache-dir --requirement /usr/share/container-setup/requirements-replication.txt
 
 
-FROM registry.access.redhat.com/ubi10-minimal:10.0-1751880071 AS final
+FROM base AS final
 
 ENV VENV=/opt/venvs/roadmap
 ENV PYTHON="${VENV}/bin/python"


### PR DESCRIPTION
ubi10-minimal was updated yesterday and includes `librepo-1.18.0-5.el10_0`.

Pin the base image at a specific tag in order to avoid spontaneous breakage.