### PR TITLE
Use `gha-update` to update GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.2.2
 
     - name: Install Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5.6.0
       with:
         python-version: "3.12"
 
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -60,7 +60,7 @@ jobs:
           pytest --cov-report=xml
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5.4.3
         with:
           env_vars: OS,PYTHON
           file: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,8 @@ jobs:
         uses: codecov/codecov-action@v5.4.3
         with:
           env_vars: OS,PYTHON
-          file: ./coverage.xml
+          disable_search: true
+          files: ./coverage.xml
           fail_ci_if_error: true
           flags: unittests
           name: codecov-umbrella

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,4 +69,3 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
+[tool.gha-update]
+tag-only = [
+    "actions/checkout",
+    "actions/setup-python",
+    "codecov/codecov-action",
+    "pre-commit/action",
+]
+
 [tool.ruff]
 line-length = 120
 indent-width = 4


### PR DESCRIPTION
Add configuration for `gha-update` and update actions.

The update to the Coverage action may require configuration changes.