### PR TITLE
Add environment parameter for getting offline token

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,14 @@ This runs a server using the default virtual environment. Documentation can be f
 In order to query host inventory, a Red Hat API access token is required. Access tokens are only valid for fifteen minutes and require an [offline token] in order to generate new ones.
 
 ```
-export RH_OFFLINE_TOKEN="[offline token]"
+export RH_OFFLINE_TOKEN_PROD="[offline token]"
 export RH_TOKEN="$(./scripts/get-redhat-access-token.py)"
+```
+
+To query the Stage environment, set an appropriate token and pass in the environment parameter.
+```
+export RH_OFFLINE_TOKEN_STAGE="[offline token]"
+export RH_TOKEN="$(./scripts/get-redhat-access-token.py -e stage)"
 ```
 
 Use the access token in the request header. Here is an example using [httpie].

--- a/scripts/get-redhat-access-token.py
+++ b/scripts/get-redhat-access-token.py
@@ -22,10 +22,11 @@ def main():
     )
     args = parser.parse_args()
 
-    offline_token = os.getenv("RH_OFFLINE_TOKEN")
+    token_env_var = f"RH_OFFLINE_TOKEN_{args.env.upper()}"
+    offline_token = os.getenv(token_env_var)
     if offline_token is None:
         sys.exit(
-            "RH_OFFLINE_TOKEN is not set."
+            f"{token_env_var} is not set."
             "\nCreate an offline token by following the directions at "
             "https://access.redhat.com/articles/3626371."
         )


### PR DESCRIPTION
Separate environment variables are used for Prod and Stage tokens. Add a new command line flag, `-e, --env` allows selecting the environment.