### PR TITLE
Only get `os_major` version once

### DIFF
--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -278,7 +278,6 @@ async def systems_by_app_stream(
             missing["os_version"] += 1
             continue
 
-        os_major = system_profile.get("operating_system", {}).get("major")
         dnf_modules = system_profile.get("dnf_modules", [])
         installed_packages = system_profile.get("installed_packages", [])
 

--- a/tests/v1/lifecycle/test_app_streams.py
+++ b/tests/v1/lifecycle/test_app_streams.py
@@ -120,7 +120,7 @@ def test_get_relevant_app_stream(api_prefix, client):
     # Ideally these numbers should be calculated from the fixture data or
     # defined in one place.
     assert count == 64, "Incorrect number of items in response. Did the fixture data change?"
-    assert total == 508, "Incorrect number of hosts in response. Did the fixture data change?"
+    assert total == 509, "Incorrect number of hosts in response. Did the fixture data change?"
     assert display_names.issuperset(["Redis 5", "Redis 6", "Apache HTTPD 2.4", "MySQL 8.0"]), (
         "Missing expected items in response"
     )


### PR DESCRIPTION
Getting `os_major` again resulted in the omission of a system if it had operating_system information but no major version. This is better handled by the `rhel_major_minor` function a few lines earlier. This should have been removed when that function was added.