### PR TITLE
[RSPEED-1816] Add filtering for `application_stream_type`

### DIFF
--- a/src/roadmap/data/app_streams.py
+++ b/src/roadmap/data/app_streams.py
@@ -43,12 +43,20 @@ class AppStreamImplementation(StrEnum):
     module = "dnf_module"
 
 
+class AppStreamType(StrEnum):
+    stream = "Application Stream"
+    full = "Full Life Application Stream"
+    rolling = "Rolling Application Stream"
+    dependent = "Dependent Application Stream"
+
+
 class AppStreamEntity(BaseModel):
     """An application stream module or package."""
 
     name: str = Field(min_length=1)
     display_name: str = ""
     application_stream_name: str
+    application_stream_type: AppStreamType | None = None
     stream: str
     start_date: Date | None = None
     end_date: Date | None = Field(validation_alias=AliasChoices("end_date", "enddate"), default=None)

--- a/tests/v1/lifecycle/test_app_streams.py
+++ b/tests/v1/lifecycle/test_app_streams.py
@@ -26,14 +26,26 @@ def test_get_app_streams(api_prefix, client):
     assert "1111-11-11" not in end_dates
 
 
-def test_get_app_streams_filter(api_prefix, client):
-    result = client.get(
-        f"{api_prefix}/lifecycle/app-streams", params={"kind": "package", "application_stream_name": "nginx"}
-    )
+@pytest.mark.parametrize(
+    ("extra_params", "expected_count"),
+    (
+        ({}, 1),
+        (
+            {"application_stream_type": "Application Stream"},
+            0,
+        ),  # The expected count needs to change once the data are updated
+    ),
+)
+def test_get_app_streams_filter(api_prefix, client, extra_params, expected_count):
+    params = {
+        "kind": "package",
+        "application_stream_name": "nginx",
+    } | extra_params
+    result = client.get(f"{api_prefix}/lifecycle/app-streams", params=params)
     data = result.json().get("data", [])
 
     assert result.status_code == 200
-    assert len(data) > 0
+    assert len(data) >= expected_count
 
 
 @pytest.mark.parametrize("version", (8, 9))


### PR DESCRIPTION
Add new field `application_stream_type` and add filtering for that field. This is related to changes in #193 and the lifecycle-defs schema changes.