### PR TITLE
Add tool for getting host data from inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
+.config.toml
 .coverage
 .install
 .ruff_cache


### PR DESCRIPTION
This requires access to the cluster as well as gabi.

Log into the OpenShift cluster and store a token.
```
install -m 700 -d ~/.config/tokens
oc whomi -t > ~/.config/tokens/openshift-token-[stage|prod]
```

Run the command to get inventory.
```
./get-hosts.py -e stage -o [orgid] --scrub
```