### PR TITLE
[RSPEED-1750] Limit the amount of system profile data returned

### DIFF
--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -374,11 +374,11 @@ def streams_lt(a: str, b: str):
 
 def rhel_major_minor(system: dict) -> tuple[int, int | None]:
     # First, try operating_system
-    if system["os_major"] is not None:
+    if system.get("os_major") is not None:
         return (system["os_major"], system["os_minor"])
 
     # If we don't have the data in operating_system, fall back to os_release
-    if (os_release := system["os_release"]) is not None:
+    if (os_release := system.get("os_release")) is not None:
         major, minor = tuple(int(n) for n in os_release.split("."))[:2]
         return (major, minor)
 

--- a/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
@@ -46,7 +46,7 @@ def test_get_relevant_app_stream(api_prefix, client):
     # Ideally these numbers should be calculated from the fixture data or
     # defined in one place.
     assert count == 59, "Incorrect number of items in response. Did the fixture data change?"
-    assert total == 456, "Incorrect number of hosts in response. Did the fixture data change?"
+    assert total == 455, "Incorrect number of hosts in response. Did the fixture data change?"
     assert display_names.issuperset(["Redis 5", "Redis 6", "Apache HTTPD 2.4", "MySQL 8.0"]), (
         "Missing expected items in response"
     )


### PR DESCRIPTION
By reducing the amount of data returned from the database, the overall response time is lowered.