### PR TITLE
[RSPEED-1874] Correct matching for upcoming items

### DIFF
--- a/requirements/requirements-dev-3.12.txt
+++ b/requirements/requirements-dev-3.12.txt
@@ -5,7 +5,6 @@ cfgv==3.4.0
 decorator==5.2.1
 distlib==0.4.0
 executing==2.2.0
-Faker==37.5.3
 filelock==3.19.1
 identify==2.6.13
 ipdb==0.13.13
@@ -25,6 +24,5 @@ Pygments==2.19.2
 PyYAML==6.0.2
 stack-data==0.6.3
 traitlets==5.14.3
-tzdata==2025.2
 virtualenv==20.34.0
 wcwidth==0.2.13

--- a/requirements/requirements-dev-3.13.txt
+++ b/requirements/requirements-dev-3.13.txt
@@ -5,7 +5,6 @@ cfgv==3.4.0
 decorator==5.2.1
 distlib==0.4.0
 executing==2.2.0
-Faker==37.5.3
 filelock==3.19.1
 identify==2.6.13
 ipdb==0.13.13
@@ -25,6 +24,5 @@ Pygments==2.19.2
 PyYAML==6.0.2
 stack-data==0.6.3
 traitlets==5.14.3
-tzdata==2025.2
 virtualenv==20.34.0
 wcwidth==0.2.13

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -1,4 +1,3 @@
-faker
 ipdb
 ipython
 pre-commit

--- a/requirements/requirements-test-3.12.txt
+++ b/requirements/requirements-test-3.12.txt
@@ -1,5 +1,6 @@
 coverage==7.10.4
 execnet==2.1.1
+Faker==37.6.0
 iniconfig==2.1.0
 packaging==25.0
 pluggy==1.6.0
@@ -10,3 +11,4 @@ pytest-cov==6.2.1
 pytest-mock==3.14.1
 pytest-xdist==3.8.0
 ruff==0.12.10
+tzdata==2025.2

--- a/requirements/requirements-test-3.13.txt
+++ b/requirements/requirements-test-3.13.txt
@@ -1,5 +1,6 @@
 coverage==7.10.4
 execnet==2.1.1
+Faker==37.6.0
 iniconfig==2.1.0
 packaging==25.0
 pluggy==1.6.0
@@ -10,3 +11,4 @@ pytest-cov==6.2.1
 pytest-mock==3.14.1
 pytest-xdist==3.8.0
 ruff==0.12.10
+tzdata==2025.2

--- a/requirements/requirements-test.in
+++ b/requirements/requirements-test.in
@@ -1,3 +1,4 @@
+faker
 pytest
 pytest-asyncio
 pytest-cov

--- a/src/roadmap/data/__init__.py
+++ b/src/roadmap/data/__init__.py
@@ -27,9 +27,9 @@ def _modules_packages():
 def _only_app_streams(data) -> set[AppStreamEntity]:
     app_streams = set(
         stream
-        for stream in APP_STREAM_MODULES_PACKAGES
+        for stream in data
         if stream.application_stream_type in (AppStreamType.stream, AppStreamType.full)
-    )
+    )  # fmt: off
 
     return app_streams
 

--- a/src/roadmap/models.py
+++ b/src/roadmap/models.py
@@ -92,6 +92,8 @@ class SystemInfo(BaseModel):
 
     id: UUID
     display_name: str
+    os_major: int
+    os_minor: int | None
 
 
 class Lifecycle(BaseModel):

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -324,6 +324,12 @@ async def systems_by_app_stream(
             missing["os_version"] += 1
             continue
 
+        if not dnf_modules:
+            missing["dnf_modules"] += 1
+
+        if not packages:
+            missing["packages"] += 1
+
         # Store package name, os_major, system ID and display name for later processing outside the loop.
         # This substantially reduces the time it takes for this function to return.
         system_info = SystemInfo(

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -45,7 +45,7 @@ Date = t.Annotated[str | date | None, AfterValidator(ensure_date)]
 MajorVersion = t.Annotated[int | None, Path(description="Major version number", ge=8, le=10)]
 
 
-def get_module_os_major_versions(name: str) -> set[str]:
+def get_module_os_major_versions(name: str) -> set[int]:
     return OS_MAJORS_BY_APP_NAME.get(name, set())
 
 
@@ -352,7 +352,7 @@ async def systems_by_app_stream(
 
 def app_streams_from_modules(
     dnf_modules: list[dict],
-    os_major: str,
+    os_major: int,
     cache: dict[str, AppStreamKey],
 ) -> set[AppStreamKey]:
     """Return a set of normalized AppStreamKey objects for the given modules"""
@@ -461,7 +461,7 @@ class NEVRA(BaseModel, frozen=True):
 @functools.cache
 def app_stream_from_package(
     package: str,
-    os_major: str,
+    os_major: int,
 ) -> AppStreamKey | None:
     # FIXME: This approach to getting the stream from the package NEVRA is incorrect and flawed.
     #

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -337,10 +337,10 @@ async def systems_by_app_stream(
             systems_by_stream[app_stream].add(system_info)
 
     # Now process the packages outside of the host record loop
-    for args, systems in package_data.items():
+    for args, systems_info in package_data.items():
         package, os_major = args
         if app_stream := app_stream_from_package(package, os_major):
-            systems_by_stream[app_stream].update(systems)
+            systems_by_stream[app_stream].update(systems_info)
 
     if missing:
         missing_items = ", ".join(f"{key}: {value}" for key, value in missing.items())

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -46,10 +46,6 @@ Date = t.Annotated[str | date | None, AfterValidator(ensure_date)]
 MajorVersion = t.Annotated[int | None, Path(description="Major version number", ge=8, le=10)]
 
 
-def get_module_os_major_versions(name: str) -> set[int]:
-    return OS_MAJORS_BY_APP_NAME.get(name, set())
-
-
 async def filter_app_stream_results(data, filter_params):
     if name := filter_params.get("name"):
         name = name.casefold()
@@ -374,7 +370,7 @@ def app_streams_from_modules(
             # Bug with Perl data currently. Omit for now.
             continue
 
-        if os_major not in get_module_os_major_versions(module_name):
+        if os_major not in OS_MAJORS_BY_APP_NAME.get(module_name, []):
             continue
 
         matched_module = APP_STREAM_MODULES_BY_KEY.get((module_name, os_major, stream))

--- a/src/roadmap/v1/upcoming.py
+++ b/src/roadmap/v1/upcoming.py
@@ -181,15 +181,11 @@ async def packages_by_system(
 
 
 def get_upcoming_data_with_hosts(
-    packages_by_system: t.Annotated[t.Any, Depends(packages_by_system)],
+    packages_by_system: t.Annotated[dict[SystemInfo, set[str]], Depends(packages_by_system)],
     settings: t.Annotated[Settings, Depends(Settings.create)],
     all: bool = False,
 ) -> list[UpcomingOutput]:
     os_major_versions = {system.os_major for system in packages_by_system}
-    try:
-        os_major_versions.remove(None)
-    except KeyError:
-        pass
 
     result = []
     for upcoming in read_upcoming_file(settings.upcoming_json_path):

--- a/src/roadmap/v1/upcoming.py
+++ b/src/roadmap/v1/upcoming.py
@@ -165,9 +165,13 @@ async def packages_by_system(
         system_info = SystemInfo(
             id=system["id"], display_name=system["display_name"], os_major=os_major, os_minor=os_minor
         )
-        for package in packages:
-            package = NEVRA.from_string(package).name
-            packages_by_system[system_info].add(package)
+
+        # The time and space complexity of this line is very high.
+        # The result of NEVRA.from_string() is cached, which helps a lot.
+        #
+        # In the future, it will most likely be necessary to store the NEVRA object and not just
+        # the package name to improve matching.
+        packages_by_system[system_info] = {NEVRA.from_string(package).name for package in packages}
 
     if missing:
         missing_items = ", ".join(f"{key}: {value}" for key, value in missing.items())

--- a/src/roadmap/v1/upcoming.py
+++ b/src/roadmap/v1/upcoming.py
@@ -149,7 +149,6 @@ async def packages_by_system(
 
     missing = defaultdict(int)
     packages_by_system = defaultdict(set)
-    package_data = defaultdict(list)
     async for system in systems.yield_per(2_000).mappings():
         packages = system["packages"] or []
 
@@ -166,7 +165,6 @@ async def packages_by_system(
         system_info = SystemInfo(
             id=system["id"], display_name=system["display_name"], os_major=os_major, os_minor=os_minor
         )
-        # TODO: This is probably crazy slow with a large number of hosts.
         for package in packages:
             package = NEVRA.from_string(package).name
             packages_by_system[system_info].add(package)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 import pytest
 
+from faker import Faker
 from fastapi.testclient import TestClient
 
 from roadmap.config import Settings
@@ -92,8 +93,13 @@ def ids_by_os(read_json_fixture):
 
 @pytest.fixture
 def make_systems():
+    fake = Faker()
+
     def _make_systems(count=3):
-        systems = {SystemInfo(id=uuid4(), display_name=f"System {n}") for n in range(count)}
+        systems = {
+            SystemInfo(id=uuid4(), display_name=f"System {n}", os_major=fake.random_int(min=8, max=10), os_minor=None)
+            for n in range(count)
+        }
         system_ids = {system.id for system in systems}
 
         return system_ids, systems

--- a/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
@@ -46,7 +46,7 @@ def test_get_relevant_app_stream(api_prefix, client):
     # Ideally these numbers should be calculated from the fixture data or
     # defined in one place.
     assert count == 59, "Incorrect number of items in response. Did the fixture data change?"
-    assert total == 455, "Incorrect number of hosts in response. Did the fixture data change?"
+    assert total == 457, "Incorrect number of hosts in response. Did the fixture data change?"
     assert display_names.issuperset(["Redis 5", "Redis 6", "Apache HTTPD 2.4", "MySQL 8.0"]), (
         "Missing expected items in response"
     )


### PR DESCRIPTION
Create a view of packages by host and use that when matching upcoming items.

Based on the current values, people interpret that field to accept a glob, a comma delimited list of packages, and a proper name of project. The matching right now explicitly compares the literal string values, which will miss a whole lot of matches. This will be addressed in a future change.