### PR TITLE
Add make target for tagging releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,10 @@ build: check-container-runtime
 get-release-commit:
 	@$(PYTHON) $(PROJECT_DIR)/scripts/get-release-commit.py
 
-.PHONY:
+.PHONY: bump-release
 bump-release:
 	@$(PYTHON) $(PROJECT_DIR)/scripts/bump-release.py
+
+.PHONY: tag
+tag:
+	@$(PYTHON) $(PROJECT_DIR)/scripts/tag-release.py

--- a/scripts/tag-release.py
+++ b/scripts/tag-release.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+
+import dataclasses
+import datetime
+import subprocess
+import sys
+import textwrap
+
+
+@dataclasses.dataclass
+class Tagger:
+    branch: str
+
+    @property
+    def tags(self) -> list[str]:
+        result = subprocess.run(
+            ["git", "tag", "--list", "--format=%(refname:short).%(objectname)", "--sort=-refname"],
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip().splitlines()
+
+    @property
+    def latest_tag(self) -> str:
+        return self.tags[0]
+
+    @property
+    def latest_commit(self) -> str:
+        result = subprocess.run(["git", "rev-parse", self.branch], capture_output=True, text=True)
+        return result.stdout.rstrip()
+
+    def tag_release(self):
+        today = datetime.date.today()
+        latest_tag_date, count, commit = self.latest_tag.rsplit(".")
+        latest_tag_date = datetime.date.fromisoformat(latest_tag_date)
+        count = int(count)
+
+        if latest_tag_date == today:
+            count += 1
+
+        for idx, tag in enumerate(self.tags):
+            if self.latest_commit in tag:
+                break
+        else:
+            release_tag = f"{today}.{count:02}"
+            subprocess.run(["git", "tag", release_tag, self.latest_commit])
+            print(f"Tagged {self.latest_commit} with {release_tag}.")
+            return
+
+        print(f"Commit {self.latest_commit:7} is already tagged.")
+        tags = self.tags[:]
+        tags[idx] += " <--"
+        sys.exit(textwrap.indent("\n".join(tags), " " * 4))
+
+
+if __name__ == "__main__":
+    tagger = Tagger("main")
+    tagger.tag_release()


### PR DESCRIPTION
Check existing tags to make sure the same commit does not get tagged more than once even though this is allowed with git.