### PR TITLE
[RSPEED-2763] Improve related calculation

### DIFF
--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -295,19 +295,30 @@ def related_app_streams(app_streams: t.Iterable[AppStreamKey]) -> set[AppStreamK
     """Return unique list of related apps that do not appear in app_streams."""
     relateds = set()
     for app_stream_key in app_streams:
+        # Extract base product name from application_stream_name by removing trailing numbers
+        # E.g., "Node.js 22" -> "Node.js", "PostgreSQL 15" -> "PostgreSQL"
+        installed_app_name = app_stream_key.app_stream_entity.application_stream_name
+        installed_base = installed_app_name.rstrip('0123456789. ')
+
         for app in APP_STREAM_MODULES_PACKAGES:
             add = False
-            # Match by application_stream_name instead of display_name to allow different versions to match
-            if app.application_stream_name == app_stream_key.app_stream_entity.application_stream_name:
+            # Match by base product name to allow different versions to match
+            # E.g., both "Node.js 22" and "Node.js 24" have base "Node.js"
+            candidate_base = app.application_stream_name.rstrip('0123456789. ')
+
+            if candidate_base == installed_base:
                 # Case 1: Same RHEL version - show newer stream versions
                 if app.os_major == app_stream_key.app_stream_entity.os_major:
                     if streams_lt(app_stream_key.app_stream_entity.stream, app.stream):
                         if app.end_date is None or app.end_date > date.today():  # pyright: ignore [reportArgumentType, reportOperatorIssue]
                             add = True
                 # Case 2: Newer RHEL version - show streams with later start_date
-                elif app.start_date and app_stream_key.app_stream_entity.start_date:
-                    if app.start_date > app_stream_key.app_stream_entity.start_date:  # pyright: ignore [reportArgumentType, reportOperatorIssue]
-                        add = True
+                # Only show streams on newer RHEL versions (not older ones)
+                elif app.os_major and app_stream_key.app_stream_entity.os_major:
+                    if app.os_major > app_stream_key.app_stream_entity.os_major:
+                        if app.start_date and app_stream_key.app_stream_entity.start_date:
+                            if app.start_date > app_stream_key.app_stream_entity.start_date:  # pyright: ignore [reportArgumentType, reportOperatorIssue]
+                                add = True
             if add:
                 relateds.add(AppStreamKey(app_stream_entity=app, name=app_stream_key.name))
 

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -298,27 +298,30 @@ def related_app_streams(app_streams: t.Iterable[AppStreamKey]) -> set[AppStreamK
         # Extract base product name from application_stream_name by removing trailing numbers
         # E.g., "Node.js 22" -> "Node.js", "PostgreSQL 15" -> "PostgreSQL"
         installed_app_name = app_stream_key.app_stream_entity.application_stream_name
-        installed_base = installed_app_name.rstrip('0123456789. ')
+        installed_base = installed_app_name.rstrip("0123456789. ")
 
-        for app in APP_STREAM_MODULES_PACKAGES:
+        filtered_apps = [
+            app
+            for app in APP_STREAM_MODULES_PACKAGES
+            if app.application_stream_name.rstrip("0123456789. ") == installed_base
+        ]
+
+        for app in filtered_apps:
             add = False
-            # Match by base product name to allow different versions to match
-            # E.g., both "Node.js 22" and "Node.js 24" have base "Node.js"
-            candidate_base = app.application_stream_name.rstrip('0123456789. ')
-
-            if candidate_base == installed_base:
+            # Safety check: both os_major values must exist
+            if app.os_major and app_stream_key.app_stream_entity.os_major:
                 # Case 1: Same RHEL version - show newer stream versions
                 if app.os_major == app_stream_key.app_stream_entity.os_major:
-                    if streams_lt(app_stream_key.app_stream_entity.stream, app.stream):
-                        if app.end_date is None or app.end_date > date.today():  # pyright: ignore [reportArgumentType, reportOperatorIssue]
-                            add = True
+                    if app.stream and app_stream_key.app_stream_entity.stream:
+                        if streams_lt(app_stream_key.app_stream_entity.stream, app.stream):
+                            if app.end_date is None or app.end_date > date.today():  # pyright: ignore [reportArgumentType, reportOperatorIssue]
+                                add = True
                 # Case 2: Newer RHEL version - show streams with later start_date
                 # Only show streams on newer RHEL versions (not older ones)
-                elif app.os_major and app_stream_key.app_stream_entity.os_major:
-                    if app.os_major > app_stream_key.app_stream_entity.os_major:
-                        if app.start_date and app_stream_key.app_stream_entity.start_date:
-                            if app.start_date > app_stream_key.app_stream_entity.start_date:  # pyright: ignore [reportArgumentType, reportOperatorIssue]
-                                add = True
+                elif app.os_major > app_stream_key.app_stream_entity.os_major:
+                    if app.start_date and app_stream_key.app_stream_entity.start_date:
+                        if app.start_date > app_stream_key.app_stream_entity.start_date:  # pyright: ignore [reportArgumentType, reportOperatorIssue]
+                            add = True
             if add:
                 relateds.add(AppStreamKey(app_stream_entity=app, name=app_stream_key.name))
 

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -297,12 +297,16 @@ def related_app_streams(app_streams: t.Iterable[AppStreamKey]) -> set[AppStreamK
     for app_stream_key in app_streams:
         for app in APP_STREAM_MODULES_PACKAGES:
             add = False
-            if app.display_name == app_stream_key.app_stream_entity.display_name:
-                if app.start_date and app_stream_key.app_stream_entity.start_date:
+            # Match by application_stream_name instead of display_name to allow different versions to match
+            if app.application_stream_name == app_stream_key.app_stream_entity.application_stream_name:
+                # Case 1: Same RHEL version - show newer stream versions
+                if app.os_major == app_stream_key.app_stream_entity.os_major:
+                    if streams_lt(app_stream_key.app_stream_entity.stream, app.stream):
+                        if app.end_date is None or app.end_date > date.today():  # pyright: ignore [reportArgumentType, reportOperatorIssue]
+                            add = True
+                # Case 2: Newer RHEL version - show streams with later start_date
+                elif app.start_date and app_stream_key.app_stream_entity.start_date:
                     if app.start_date > app_stream_key.app_stream_entity.start_date:  # pyright: ignore [reportArgumentType, reportOperatorIssue]
-                        add = True
-                elif streams_lt(app_stream_key.app_stream_entity.stream, app.stream):
-                    if app.end_date is None or app.end_date > date.today():  # pyright: ignore [reportArgumentType, reportOperatorIssue]
                         add = True
             if add:
                 relateds.add(AppStreamKey(app_stream_entity=app, name=app_stream_key.name))

--- a/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
@@ -568,7 +568,8 @@ def test_relevant_app_stream_with_systems_not_marked_as_not_installed():
 
 def test_related_app_streams_with_none_os_major():
     """Test related_app_streams handles None os_major values."""
-    from roadmap.v1.lifecycle.app_streams import AppStreamKey, related_app_streams
+    from roadmap.v1.lifecycle.app_streams import AppStreamKey
+    from roadmap.v1.lifecycle.app_streams import related_app_streams
 
     # Create an app stream with None os_major
     app_stream_entity = AppStreamEntity(
@@ -606,8 +607,9 @@ def test_app_stream_from_package_no_match():
 
 def test_related_app_streams_with_empty_stream(mocker):
     """Test related_app_streams when stream is empty string."""
-    from roadmap.v1.lifecycle.app_streams import AppStreamKey, related_app_streams
     from roadmap.data import APP_STREAM_MODULES_PACKAGES
+    from roadmap.v1.lifecycle.app_streams import AppStreamKey
+    from roadmap.v1.lifecycle.app_streams import related_app_streams
 
     # Mock APP_STREAM_MODULES_PACKAGES to include an entry with empty stream
     mock_app = AppStreamEntity(
@@ -622,10 +624,7 @@ def test_related_app_streams_with_empty_stream(mocker):
     )
 
     original_packages = list(APP_STREAM_MODULES_PACKAGES)
-    mocker.patch(
-        "roadmap.v1.lifecycle.app_streams.APP_STREAM_MODULES_PACKAGES",
-        original_packages + [mock_app]
-    )
+    mocker.patch("roadmap.v1.lifecycle.app_streams.APP_STREAM_MODULES_PACKAGES", original_packages + [mock_app])
 
     # Create an app stream that would match base name
     app_stream_entity = AppStreamEntity(
@@ -649,7 +648,7 @@ def test_related_app_streams_with_empty_stream(mocker):
 def test_app_stream_from_package_os_major_mismatch():
     """Test app_stream_from_package when package os_major doesn't match lookup key."""
     import importlib
-    from roadmap.v1 import lifecycle
+
     from roadmap.v1.lifecycle import app_streams as app_streams_module
 
     # Reload the module to clear functools.cache
@@ -671,6 +670,7 @@ def test_app_stream_from_package_os_major_mismatch():
 
     # Directly modify APP_STREAM_PACKAGES
     from roadmap.data import APP_STREAM_PACKAGES
+
     if 9 not in APP_STREAM_PACKAGES:
         APP_STREAM_PACKAGES[9] = {}
     APP_STREAM_PACKAGES[9]["testpkg"] = mock_package
@@ -689,7 +689,8 @@ def test_app_stream_from_package_os_major_mismatch():
 
 def test_related_app_streams_with_none_start_date():
     """Test related_app_streams handles None start_date in Case 2."""
-    from roadmap.v1.lifecycle.app_streams import AppStreamKey, related_app_streams
+    from roadmap.v1.lifecycle.app_streams import AppStreamKey
+    from roadmap.v1.lifecycle.app_streams import related_app_streams
 
     # Create an app stream with None start_date
     app_stream_entity = AppStreamEntity(
@@ -712,7 +713,8 @@ def test_related_app_streams_with_none_start_date():
 
 def test_get_relevant_app_stream_exception_in_related(api_prefix, client, mocker):
     """Test exception handling in the related app streams endpoint."""
-    from roadmap.common import decode_header, query_rbac
+    from roadmap.common import decode_header
+    from roadmap.common import query_rbac
 
     async def query_rbac_override():
         return [{"permission": "inventory:*:*", "resourceDefinitions": []}]
@@ -727,6 +729,7 @@ def test_get_relevant_app_stream_exception_in_related(api_prefix, client, mocker
             raise ValueError("Test exception for coverage")
         # Otherwise call the real constructor
         from roadmap.v1.lifecycle.app_streams import RelevantAppStream
+
         return RelevantAppStream.model_validate(kwargs)
 
     mocker.patch(
@@ -763,10 +766,7 @@ def test_app_stream_items_response_rolling_with_missing_os_data(mocker):
     )
 
     # Create response with the rolling app stream
-    response = AppStreamItemsResponse(
-        meta={"count": 1, "total": 1},
-        data=[rolling_app]
-    )
+    response = AppStreamItemsResponse(meta={"count": 1, "total": 1}, data=[rolling_app])
 
     # Should not raise an error, and end_date should remain None
     assert response.data[0].end_date is None

--- a/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
@@ -198,11 +198,15 @@ def test_get_relevant_app_stream_resource_definitions_with_ungrouped_permission(
     result = client.get(f"{api_prefix}/relevant/lifecycle/app-streams?related=true")
     data = result.json().get("data", "")
     assert result.status_code == 200
-    assert len(data) == 1
-    # In the test data there is an eligible system from another group (for
-    # which the request does not have permission) that shows NGINX 1.14,
-    # and another with NGINX 1.22.
-    assert data[0]["display_name"] == "Node.js 18"
+    # The ungrouped host has Node.js 18 installed, plus related streams (Node.js 20, 22, 24, etc.)
+    installed = [item for item in data if not item.get("related", False)]
+    related = [item for item in data if item.get("related", False)]
+    assert len(installed) == 1, f"Expected 1 installed stream, got {len(installed)}"
+    assert installed[0]["display_name"] == "Node.js 18"
+    # Should have newer Node.js versions as related streams
+    assert len(related) > 0, "Expected related streams for Node.js 18"
+    related_names = {item["display_name"] for item in related}
+    assert "Node.js 20" in related_names or "Node.js 22" in related_names
 
 
 def test_get_relevant_app_stream_resource_definitions_with_ungrouped_and_grouped_permission(api_prefix, client):
@@ -232,11 +236,16 @@ def test_get_relevant_app_stream_resource_definitions_with_ungrouped_and_grouped
     client.app.dependency_overrides[decode_header] = decode_header_override
     result = client.get(f"{api_prefix}/relevant/lifecycle/app-streams?related=true")
     data = result.json().get("data", "")
+    assert result.status_code == 200
     # In the test data there is an eligible system from another group (for
     # which the request does not have permission) that shows NGINX 1.14.
-    display_names = {d["display_name"] for d in data}
-    assert {"Node.js 18", "NGINX 1.22"} == display_names
-    assert result.status_code == 200
+    # Check installed streams (count > 0)
+    installed = [d for d in data if d["count"] > 0]
+    installed_names = {d["display_name"] for d in installed}
+    assert {"Node.js 18", "NGINX 1.22"} == installed_names
+    # Should also have related streams
+    related = [d for d in data if d.get("related", False)]
+    assert len(related) > 0, "Expected related streams"
 
 
 def test_get_revelent_app_stream_related(api_prefix, client, mocker):
@@ -322,11 +331,15 @@ def test_get_revelent_app_stream_related_with_group_permissions(api_prefix, clie
     result = client.get(f"{api_prefix}/relevant/lifecycle/app-streams?related=true")
     data = result.json().get("data", "")
     assert result.status_code == 200
-    assert len(data) == 2
     # In the test data there is an eligible system from another group (for
     # which the request does not have permission) that shows NGINX 1.14,
     # and another with nodejs 18.
-    assert data[0]["display_name"] == "NGINX 1.22"
+    # Check that NGINX 1.22 is in the installed streams
+    installed = [d for d in data if d["count"] > 0]
+    installed_names = {d["display_name"] for d in installed}
+    assert "NGINX 1.22" in installed_names
+    # Should have at least the installed stream (may also have related streams)
+    assert len(data) >= 1
 
 
 def test_app_stream_missing_lifecycle_data():

--- a/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
@@ -564,3 +564,209 @@ def test_relevant_app_stream_with_systems_not_marked_as_not_installed():
     # Should calculate normal status (supported in this case)
     assert app_stream.support_status == SupportStatus.supported
     assert app_stream.count == 5
+
+
+def test_related_app_streams_with_none_os_major():
+    """Test related_app_streams handles None os_major values."""
+    from roadmap.v1.lifecycle.app_streams import AppStreamKey, related_app_streams
+
+    # Create an app stream with None os_major
+    app_stream_entity = AppStreamEntity(
+        name="nodejs",
+        stream="22",
+        display_name="Node.js 22",
+        application_stream_name="Node.js 22",
+        start_date=date(2024, 1, 1),
+        end_date=date(2026, 1, 1),
+        os_major=None,  # None to trigger the safety check
+        impl=AppStreamImplementation.module,
+    )
+
+    app_stream_key = AppStreamKey(app_stream_entity=app_stream_entity, name="nodejs")
+
+    # Should return empty set without error when os_major is None
+    result = related_app_streams([app_stream_key])
+    assert isinstance(result, set)
+
+
+def test_app_stream_from_package_no_match():
+    """Test app_stream_from_package returns None when package doesn't match stream."""
+    from roadmap.v1.lifecycle.app_streams import app_stream_from_package
+
+    # Test with a package that exists but version doesn't match
+    # This tests the exit path where stream != [major, minor]
+    result = app_stream_from_package("nodejs-999.999-1.el9.x86_64", 9)
+    assert result is None
+
+    # Also test a real package that might exist but with wrong os_major
+    # This tests line 532->exit where app_stream_package.os_major != os_major
+    result = app_stream_from_package("postgresql-13.0-1.el8.x86_64", 10)  # Wrong OS
+    assert result is None
+
+
+def test_related_app_streams_with_empty_stream(mocker):
+    """Test related_app_streams when stream is empty string."""
+    from roadmap.v1.lifecycle.app_streams import AppStreamKey, related_app_streams
+    from roadmap.data import APP_STREAM_MODULES_PACKAGES
+
+    # Mock APP_STREAM_MODULES_PACKAGES to include an entry with empty stream
+    mock_app = AppStreamEntity(
+        name="test",
+        stream="",  # Empty string to trigger line 315->325
+        display_name="Test",
+        application_stream_name="Test",
+        start_date=date(2024, 1, 1),
+        end_date=date(2026, 1, 1),
+        os_major=9,
+        impl=AppStreamImplementation.module,
+    )
+
+    original_packages = list(APP_STREAM_MODULES_PACKAGES)
+    mocker.patch(
+        "roadmap.v1.lifecycle.app_streams.APP_STREAM_MODULES_PACKAGES",
+        original_packages + [mock_app]
+    )
+
+    # Create an app stream that would match base name
+    app_stream_entity = AppStreamEntity(
+        name="test",
+        stream="1.0",
+        display_name="Test 1.0",
+        application_stream_name="Test",
+        start_date=date(2024, 1, 1),
+        end_date=date(2026, 1, 1),
+        os_major=9,
+        impl=AppStreamImplementation.module,
+    )
+
+    app_stream_key = AppStreamKey(app_stream_entity=app_stream_entity, name="test")
+
+    # Should handle empty stream gracefully
+    result = related_app_streams([app_stream_key])
+    assert isinstance(result, set)
+
+
+def test_app_stream_from_package_os_major_mismatch():
+    """Test app_stream_from_package when package os_major doesn't match lookup key."""
+    import importlib
+    from roadmap.v1 import lifecycle
+    from roadmap.v1.lifecycle import app_streams as app_streams_module
+
+    # Reload the module to clear functools.cache
+    importlib.reload(app_streams_module)
+
+    from roadmap.v1.lifecycle.app_streams import app_stream_from_package
+
+    # Create a mock package with mismatched os_major
+    mock_package = AppStreamEntity(
+        name="testpkg",
+        stream="1.0",
+        display_name="Test Package 1.0",
+        application_stream_name="Test Package",
+        start_date=date(2024, 1, 1),
+        end_date=date(2026, 1, 1),
+        os_major=8,  # Different from the lookup key
+        impl=AppStreamImplementation.package,
+    )
+
+    # Directly modify APP_STREAM_PACKAGES
+    from roadmap.data import APP_STREAM_PACKAGES
+    if 9 not in APP_STREAM_PACKAGES:
+        APP_STREAM_PACKAGES[9] = {}
+    APP_STREAM_PACKAGES[9]["testpkg"] = mock_package
+
+    try:
+        # Should return None because os_major mismatch (8 != 9)
+        result = app_stream_from_package("testpkg-1.0-1.el9.x86_64", 9)
+        assert result is None
+    finally:
+        # Clean up
+        if "testpkg" in APP_STREAM_PACKAGES.get(9, {}):
+            del APP_STREAM_PACKAGES[9]["testpkg"]
+        # Reload again to clear cache
+        importlib.reload(app_streams_module)
+
+
+def test_related_app_streams_with_none_start_date():
+    """Test related_app_streams handles None start_date in Case 2."""
+    from roadmap.v1.lifecycle.app_streams import AppStreamKey, related_app_streams
+
+    # Create an app stream with None start_date
+    app_stream_entity = AppStreamEntity(
+        name="nodejs",
+        stream="22",
+        display_name="Node.js 22",
+        application_stream_name="Node.js 22",
+        start_date=None,  # None to trigger the safety check in Case 2
+        end_date=date(2026, 1, 1),
+        os_major=9,
+        impl=AppStreamImplementation.module,
+    )
+
+    app_stream_key = AppStreamKey(app_stream_entity=app_stream_entity, name="nodejs")
+
+    # Should return empty set without error when start_date is None
+    result = related_app_streams([app_stream_key])
+    assert isinstance(result, set)
+
+
+def test_get_relevant_app_stream_exception_in_related(api_prefix, client, mocker):
+    """Test exception handling in the related app streams endpoint."""
+    from roadmap.common import decode_header, query_rbac
+
+    async def query_rbac_override():
+        return [{"permission": "inventory:*:*", "resourceDefinitions": []}]
+
+    async def decode_header_override():
+        return "1234"
+
+    # Mock RelevantAppStream to raise an exception when building related items
+    def mock_relevant_app_stream(*args, **kwargs):
+        # Raise exception only for related=True items
+        if kwargs.get("related", False):
+            raise ValueError("Test exception for coverage")
+        # Otherwise call the real constructor
+        from roadmap.v1.lifecycle.app_streams import RelevantAppStream
+        return RelevantAppStream.model_validate(kwargs)
+
+    mocker.patch(
+        "roadmap.v1.lifecycle.app_streams.RelevantAppStream",
+        side_effect=mock_relevant_app_stream,
+    )
+
+    client.app.dependency_overrides = {}
+    client.app.dependency_overrides[query_rbac] = query_rbac_override
+    client.app.dependency_overrides[decode_header] = decode_header_override
+
+    result = client.get(f"{api_prefix}/relevant/lifecycle/app-streams", params={"related": True})
+
+    # Should return 400 error with exception detail
+    assert result.status_code == 400
+    assert "Test exception for coverage" in result.json()["detail"]
+
+
+def test_app_stream_items_response_rolling_with_missing_os_data(mocker):
+    """Test set_end_date_support_status when OS_LIFECYCLE_DATES doesn't have the os_major."""
+    from roadmap.v1.lifecycle.app_streams import AppStreamItemsResponse
+
+    # Create a rolling app stream with os_major that doesn't exist in OS_LIFECYCLE_DATES
+    rolling_app = AppStreamEntity(
+        name="test",
+        stream="1.0",
+        display_name="Test 1.0",
+        application_stream_name="Test",
+        start_date=date(2024, 1, 1),
+        end_date=None,
+        os_major=999,  # Non-existent OS major version
+        rolling=True,
+        impl=AppStreamImplementation.module,
+    )
+
+    # Create response with the rolling app stream
+    response = AppStreamItemsResponse(
+        meta={"count": 1, "total": 1},
+        data=[rolling_app]
+    )
+
+    # Should not raise an error, and end_date should remain None
+    assert response.data[0].end_date is None


### PR DESCRIPTION
This PR fixed the related_app_streams function to compare by base product name instead of exact display_name and updated test expectations to account for the now-working related streams feature.

Before:
<img width="1541" height="947" alt="image" src="https://github.com/user-attachments/assets/7f9e08c5-049d-4ced-92d6-8a053515c4d9" />

After:
<img width="1541" height="947" alt="image" src="https://github.com/user-attachments/assets/05a59943-f2d7-46b9-9781-1326b1efd127" />
