### PR TITLE
[RSPEED-2637] Ensure EOL packages are not considered related

### DIFF
--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -291,6 +291,25 @@ class ModuleStatus(StrEnum):
     installed = auto()
 
 
+def _is_not_eol(app: AppStreamEntity) -> bool:
+    """Check if an app stream is not past its end of life date."""
+    return app.end_date is None or app.end_date > date.today()  # pyright: ignore [reportArgumentType, reportOperatorIssue]
+
+
+def _should_add_same_rhel_version(app: AppStreamEntity, installed: AppStreamEntity) -> bool:
+    """Check if app should be added as related for same RHEL version (newer stream)."""
+    if not (app.stream and installed.stream):
+        return False
+    return streams_lt(installed.stream, app.stream) and _is_not_eol(app)
+
+
+def _should_add_newer_rhel_version(app: AppStreamEntity, installed: AppStreamEntity) -> bool:
+    """Check if app should be added as related for newer RHEL version."""
+    if not (app.start_date and installed.start_date):
+        return False
+    return app.start_date > installed.start_date and _is_not_eol(app)  # pyright: ignore [reportArgumentType, reportOperatorIssue]
+
+
 def related_app_streams(app_streams: t.Iterable[AppStreamKey]) -> set[AppStreamKey]:
     """Return unique list of related apps that do not appear in app_streams."""
     relateds = set()
@@ -308,22 +327,15 @@ def related_app_streams(app_streams: t.Iterable[AppStreamKey]) -> set[AppStreamK
 
         for app in filtered_apps:
             add = False
+            installed = app_stream_key.app_stream_entity
             # Safety check: both os_major values must exist
-            if app.os_major and app_stream_key.app_stream_entity.os_major:
+            if app.os_major and installed.os_major:
                 # Case 1: Same RHEL version - show newer stream versions
-                if app.os_major == app_stream_key.app_stream_entity.os_major:
-                    if app.stream and app_stream_key.app_stream_entity.stream:
-                        if streams_lt(app_stream_key.app_stream_entity.stream, app.stream):
-                            if app.end_date is None or app.end_date > date.today():  # pyright: ignore [reportArgumentType, reportOperatorIssue]
-                                add = True
+                if app.os_major == installed.os_major:
+                    add = _should_add_same_rhel_version(app, installed)
                 # Case 2: Newer RHEL version - show streams with later start_date
-                # Only show streams on newer RHEL versions (not older ones)
-                elif app.os_major > app_stream_key.app_stream_entity.os_major:
-                    if app.start_date and app_stream_key.app_stream_entity.start_date:
-                        if app.start_date > app_stream_key.app_stream_entity.start_date:  # pyright: ignore [reportArgumentType, reportOperatorIssue]
-                            # Don't show EOL streams as related
-                            if app.end_date is None or app.end_date > date.today():  # pyright: ignore [reportArgumentType, reportOperatorIssue]
-                                add = True
+                elif app.os_major > installed.os_major:
+                    add = _should_add_newer_rhel_version(app, installed)
             if add:
                 relateds.add(AppStreamKey(app_stream_entity=app, name=app_stream_key.name))
 

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -321,7 +321,9 @@ def related_app_streams(app_streams: t.Iterable[AppStreamKey]) -> set[AppStreamK
                 elif app.os_major > app_stream_key.app_stream_entity.os_major:
                     if app.start_date and app_stream_key.app_stream_entity.start_date:
                         if app.start_date > app_stream_key.app_stream_entity.start_date:  # pyright: ignore [reportArgumentType, reportOperatorIssue]
-                            add = True
+                            # Don't show EOL streams as related
+                            if app.end_date is None or app.end_date > date.today():  # pyright: ignore [reportArgumentType, reportOperatorIssue]
+                                add = True
             if add:
                 relateds.add(AppStreamKey(app_stream_entity=app, name=app_stream_key.name))
 

--- a/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
@@ -770,3 +770,128 @@ def test_app_stream_items_response_rolling_with_missing_os_data(mocker):
 
     # Should not raise an error, and end_date should remain None
     assert response.data[0].end_date is None
+
+
+def test_related_does_not_include_eol_streams_newer_rhel_version(mocker):
+    """Regression test: EOL streams on newer RHEL should be filtered ."""
+    from roadmap.v1.lifecycle.app_streams import AppStreamKey
+    from roadmap.v1.lifecycle.app_streams import related_app_streams
+
+    # NGINX 1.20 on RHEL 8 (installed)
+    nginx_120_rhel8 = AppStreamEntity(
+        name="nginx",
+        stream="1.20",
+        display_name="NGINX 1.20",
+        application_stream_name="NGINX",
+        application_stream_type=AppStreamType.stream,
+        start_date=date(2021, 5, 17),
+        end_date=date(2023, 5, 31),
+        os_major=8,
+        impl=AppStreamImplementation.module,
+    )
+
+    # NGINX 1.22 on RHEL 9 (potential related, but EOL) - THIS WAS THE BUG
+    nginx_122_rhel9 = AppStreamEntity(
+        name="nginx",
+        stream="1.22",
+        display_name="NGINX 1.22",
+        application_stream_name="NGINX",
+        application_stream_type=AppStreamType.stream,
+        start_date=date(2022, 5, 17),  # After RHEL 8 version
+        end_date=date(2024, 6, 1),  # Past EOL
+        os_major=9,  # Newer RHEL version
+        impl=AppStreamImplementation.module,
+    )
+
+    # NGINX 1.24 on RHEL 9 (potential related, NOT EOL)
+    nginx_124_rhel9 = AppStreamEntity(
+        name="nginx",
+        stream="1.24",
+        display_name="NGINX 1.24",
+        application_stream_name="NGINX",
+        application_stream_type=AppStreamType.stream,
+        start_date=date(2023, 5, 17),  # After RHEL 8 version
+        end_date=date(2026, 5, 31),  # Still supported
+        os_major=9,
+        impl=AppStreamImplementation.module,
+    )
+
+    # Mock today's date to be after NGINX 1.22 EOL
+    mock_date = mocker.patch("roadmap.v1.lifecycle.app_streams.date", wraps=date)
+    mock_date.today.return_value = date(2025, 1, 1)
+
+    # Mock APP_STREAM_MODULES_PACKAGES
+    mocker.patch(
+        "roadmap.v1.lifecycle.app_streams.APP_STREAM_MODULES_PACKAGES",
+        [nginx_120_rhel8, nginx_122_rhel9, nginx_124_rhel9],
+    )
+
+    installed_key = AppStreamKey(app_stream_entity=nginx_120_rhel8, name="nginx")
+    result = related_app_streams([installed_key])
+
+    # Should only include NGINX 1.24 on RHEL 9 (not EOL)
+    # Should NOT include NGINX 1.22 on RHEL 9 (EOL) - THIS IS THE FIX
+    related_display_names = {r.app_stream_entity.display_name for r in result}
+    related_os_majors = {(r.app_stream_entity.display_name, r.app_stream_entity.os_major) for r in result}
+
+    assert "NGINX 1.24" in related_display_names, "Should include non-EOL version on newer RHEL"
+    assert "NGINX 1.22" not in related_display_names, "Should NOT include EOL version on newer RHEL"
+    assert ("NGINX 1.24", 9) in related_os_majors
+
+
+@pytest.mark.parametrize(
+    ("end_date", "today", "should_be_included"),
+    [
+        (date(2026, 1, 1), date(2025, 12, 31), True),  # Not yet EOL
+        (date(2026, 1, 1), date(2026, 1, 1), False),  # EOL today
+        (date(2026, 1, 1), date(2026, 1, 2), False),  # Past EOL
+        (None, date(2025, 1, 1), True),  # No end_date means supported
+    ],
+)
+def test_related_eol_boundary_conditions(mocker, end_date, today, should_be_included):
+    """Test EOL filtering at exact boundaries for related streams on newer RHEL."""
+    from roadmap.v1.lifecycle.app_streams import AppStreamKey
+    from roadmap.v1.lifecycle.app_streams import related_app_streams
+
+    # Installed stream on RHEL 8
+    installed = AppStreamEntity(
+        name="test",
+        stream="1.0",
+        display_name="Test 1.0",
+        application_stream_name="Test",
+        application_stream_type=AppStreamType.stream,
+        start_date=date(2020, 1, 1),
+        end_date=date(2024, 1, 1),
+        os_major=8,
+        impl=AppStreamImplementation.module,
+    )
+
+    # Potential related stream on RHEL 9
+    related_candidate = AppStreamEntity(
+        name="test",
+        stream="2.0",
+        display_name="Test 2.0",
+        application_stream_name="Test",
+        application_stream_type=AppStreamType.stream,
+        start_date=date(2021, 1, 1),
+        end_date=end_date,
+        os_major=9,
+        impl=AppStreamImplementation.module,
+    )
+
+    mock_date = mocker.patch("roadmap.v1.lifecycle.app_streams.date", wraps=date)
+    mock_date.today.return_value = today
+
+    mocker.patch(
+        "roadmap.v1.lifecycle.app_streams.APP_STREAM_MODULES_PACKAGES",
+        [installed, related_candidate],
+    )
+
+    installed_key = AppStreamKey(app_stream_entity=installed, name="test")
+    result = related_app_streams([installed_key])
+
+    if should_be_included:
+        assert len(result) == 1, f"Expected related stream to be included when end_date={end_date}, today={today}"
+        assert list(result)[0].app_stream_entity.display_name == "Test 2.0"
+    else:
+        assert len(result) == 0, f"Expected no related streams when end_date={end_date}, today={today}"


### PR DESCRIPTION
## Fix: Filter out EOL app streams from related recommendations

### Problem

NGINX 1.22 (and other EOL app streams) were incorrectly appearing as "related" upgrade paths even when:
1. They are past their End of Life (EOL) date
2. No instances of that app stream family are installed on any systems

**Acceptance Criteria:**
- ✅ NGINX 1.22 is not considered as "related" when it's past EOL
- ✅ Related streams are only shown if `end_date > today` or `end_date is None`

### Root Cause

The `related_app_streams()` function had **inconsistent EOL filtering** between two code paths:

**Case 1** (same RHEL version - newer stream):
```python
if app.end_date is None or app.end_date > date.today():  #  EOL check
    add = True
```
**Case 2** (newer RHEL version - upgrade path):
```python
if app.start_date > app_stream_key.app_stream_entity.start_date: # No EOL check
    add = True  # 
```
Case 1 correctly filtered out EOL streams, but Case 2 did not. This meant EOL streams on newer RHEL versions (like NGINX 1.22 on RHEL 9) appeared as related even when they shouldn't.

Now both cases consistently filter out streams where end_date <= today.

Before:
<img width="1523" height="797" alt="Screenshot From 2026-04-10 11-56-31" src="https://github.com/user-attachments/assets/14006ba2-9cb4-4695-98cc-fb9c212ad55a" />
After:
<img width="1550" height="911" alt="Screenshot From 2026-04-10 11-57-17" src="https://github.com/user-attachments/assets/622de66b-3c4e-4840-a42f-609638322e06" />
