### PR TITLE
Disable notificator

### DIFF
--- a/deploy/config.yml
+++ b/deploy/config.yml
@@ -358,7 +358,7 @@ parameters:
     value: "1234"
 
   - name: NOTIFICATOR_SCHEDULE
-    value: "0 6 1 * *"
+    value: "0 0 31 2 *"
 
   - name: CPU_REQUEST_NOTIFICATOR
     value: 250m


### PR DESCRIPTION
Set notificator to Feb 31 so it never triggers. This allow us to do release without being blocked by notificator which is not yet finished.