### PR TITLE
Change notificator schedule

### DIFF
--- a/deploy/config.yml
+++ b/deploy/config.yml
@@ -394,7 +394,7 @@ parameters:
     value: '1'
 
   - name: NOTIFICATOR_SCHEDULE
-    value: "0 0 31 2 *"
+    value: "0 6 * * *"
 
   - name: CPU_REQUEST_NOTIFICATOR
     value: 250m


### PR DESCRIPTION
Change notificator schedule to run daily at 6 AM UTC time. This helps is with testing notificator in staging environment. Registered accounts receive notification daily.

This is going to be changed to monthly for production release. Now it was disabled.