### PR TITLE
[RSPEED-2874] Add TLS to kafka connection

### DIFF
--- a/src/notificator/kafka.py
+++ b/src/notificator/kafka.py
@@ -67,8 +67,8 @@ def _build_producer(settings: NotificatorSettings) -> AIOKafkaProducer:
     """
     ssl_context = _build_ssl_context(settings)
     if ssl_context:
-        return AIOKafkaProducer(  # pyright: ignore [reportArgumentType]
-            bootstrap_servers=settings.bootstrap_servers,
+        return AIOKafkaProducer(
+            bootstrap_servers=settings.bootstrap_servers,  # pyright: ignore [reportArgumentType]
             security_protocol="SSL",
             ssl_context=ssl_context,
         )

--- a/src/notificator/kafka.py
+++ b/src/notificator/kafka.py
@@ -19,9 +19,11 @@ from __future__ import annotations
 
 import asyncio
 import json
+import ssl
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 import structlog
 
@@ -40,8 +42,36 @@ class KafkaBrokersNotConfigured(Exception):
     """Raised when kafka_producer() is called without any Kafka brokers configured."""
 
 
+def _build_ssl_context(settings: NotificatorSettings) -> ssl.SSLContext | None:
+    """Return an mTLS SSLContext if the TLS cert and key files are present, else None.
+
+    In Clowder-managed environments (stage/prod) the cert and key are mounted
+    at the paths from settings. In local dev the files are absent, so we skip
+    SSL and fall back to a plain connection.
+    """
+    cert = Path(settings.tls_cert_path)
+    key = Path(settings.tls_key_path)
+    if not cert.exists() or not key.exists():
+        return None
+    ssl_context = ssl.create_default_context()
+    ssl_context.load_cert_chain(certfile=str(cert), keyfile=str(key))
+    logger.info("Kafka SSL context created")
+    return ssl_context
+
+
 def _build_producer(settings: NotificatorSettings) -> AIOKafkaProducer:
-    """Create an AIOKafkaProducer from the notificator settings."""
+    """Create an AIOKafkaProducer from the notificator settings.
+
+    Uses mTLS when TLS cert/key files are present (stage/prod Clowder mounts),
+    otherwise connects without SSL (local dev).
+    """
+    ssl_context = _build_ssl_context(settings)
+    if ssl_context:
+        return AIOKafkaProducer(  # pyright: ignore [reportArgumentType]
+            bootstrap_servers=settings.bootstrap_servers,
+            security_protocol="SSL",
+            ssl_context=ssl_context,
+        )
     return AIOKafkaProducer(bootstrap_servers=settings.bootstrap_servers)  # pyright: ignore [reportArgumentType]
 
 

--- a/src/roadmap/admin/notificator.py
+++ b/src/roadmap/admin/notificator.py
@@ -36,7 +36,7 @@ class CustomNotificatorRequest(BaseModel):
 class AllNotificatorRequest(BaseModel):
     confirm_all: bool = Field(
         default=False,
-        description="Set to true to confirm notifications should be triggered for every org.",
+        description="Set to true to confirm notifications should be triggered for every org subscribed to receive this type of notification.",
     )
 
 

--- a/tests/notificator/test_kafka.py
+++ b/tests/notificator/test_kafka.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+import ssl
 
 from types import SimpleNamespace
 
@@ -12,12 +13,97 @@ import pytest
 
 from aiokafka.errors import KafkaError
 
+from notificator.kafka import _build_producer
+from notificator.kafka import _build_ssl_context
 from notificator.kafka import _start_producer
 from notificator.kafka import kafka_producer
 from notificator.kafka import KafkaBrokersNotConfigured
 from notificator.kafka import KafkaProducer
 
 from .utils import FakeKafkaProducer
+
+
+def _make_settings(
+    *,
+    dev=False,
+    bootstrap_servers=None,
+    tls_cert_path="/tmp/tls/cert.pem",
+    tls_key_path="/tmp/tls/key.pem",
+    topic="test-topic",
+):
+    return SimpleNamespace(
+        dev=dev,
+        bootstrap_servers=["broker:9092"] if bootstrap_servers is None else bootstrap_servers,
+        tls_cert_path=tls_cert_path,
+        tls_key_path=tls_key_path,
+        notifications_topic=topic,
+    )
+
+
+class TestBuildSSLContext:
+    """_build_ssl_context: returns an SSLContext only when both cert and key files exist."""
+
+    def test_returns_none_when_cert_missing(self, tmp_path):
+        """No cert file → no SSL context (plain connection, e.g. local dev)."""
+        settings = _make_settings(
+            tls_cert_path=str(tmp_path / "missing_cert.pem"),
+            tls_key_path=str(tmp_path / "missing_key.pem"),
+        )
+        assert _build_ssl_context(settings) is None
+
+    def test_returns_none_when_key_missing(self, tmp_path):
+        """Cert present but key absent → no SSL context."""
+        cert = tmp_path / "cert.pem"
+        cert.write_text("cert-data")
+        settings = _make_settings(
+            tls_cert_path=str(cert),
+            tls_key_path=str(tmp_path / "missing_key.pem"),
+        )
+        assert _build_ssl_context(settings) is None
+
+    def test_returns_ssl_context_when_both_files_exist(self, tmp_path, mocker):
+        """Both files present → returns an ssl.SSLContext with the cert loaded."""
+        cert = tmp_path / "cert.pem"
+        key = tmp_path / "key.pem"
+        cert.write_text("cert-data")
+        key.write_text("key-data")
+        mock_ctx = mocker.MagicMock(spec=ssl.SSLContext)
+        mocker.patch("ssl.create_default_context", return_value=mock_ctx)
+        settings = _make_settings(tls_cert_path=str(cert), tls_key_path=str(key))
+
+        result = _build_ssl_context(settings)
+
+        assert result is mock_ctx
+        mock_ctx.load_cert_chain.assert_called_once_with(certfile=str(cert), keyfile=str(key))
+
+
+class TestBuildProducer:
+    """_build_producer: wires SSL context into the producer when TLS files are present."""
+
+    def test_uses_ssl_when_context_available(self, mocker):
+        """When _build_ssl_context returns a context, the producer is built with SSL."""
+        mock_ctx = mocker.MagicMock(spec=ssl.SSLContext)
+        mocker.patch("notificator.kafka._build_ssl_context", return_value=mock_ctx)
+        mock_producer_cls = mocker.patch("notificator.kafka.AIOKafkaProducer")
+        settings = _make_settings(bootstrap_servers=["broker:9096"])
+
+        _build_producer(settings)
+
+        mock_producer_cls.assert_called_once_with(
+            bootstrap_servers=["broker:9096"],
+            security_protocol="SSL",
+            ssl_context=mock_ctx,
+        )
+
+    def test_no_ssl_when_context_is_none(self, mocker):
+        """When _build_ssl_context returns None, the producer is built without SSL."""
+        mocker.patch("notificator.kafka._build_ssl_context", return_value=None)
+        mock_producer_cls = mocker.patch("notificator.kafka.AIOKafkaProducer")
+        settings = _make_settings(bootstrap_servers=["localhost:9092"])
+
+        _build_producer(settings)
+
+        mock_producer_cls.assert_called_once_with(bootstrap_servers=["localhost:9092"])
 
 
 class TestKafkaProducer:
@@ -113,19 +199,12 @@ class TestStartProducer:
 class TestKafkaProducerContextManager:
     """kafka_producer() context manager: real lifecycle, mocked settings + builder."""
 
-    def _make_settings(self, *, dev=False, bootstrap_servers=None, topic="test-topic"):
-        return SimpleNamespace(
-            dev=dev,
-            bootstrap_servers=bootstrap_servers or [],
-            notifications_topic=topic,
-        )
-
     async def test_kafka_producer_no_brokers_raises(self, mocker):
         """Without brokers (and dev=False), the context manager must raise
         KafkaBrokersNotConfigured — running without a broker is a fatal misconfiguration."""
         mocker.patch(
             "notificator.kafka.NotificatorSettings.create",
-            return_value=self._make_settings(dev=False, bootstrap_servers=[]),
+            return_value=_make_settings(dev=False, bootstrap_servers=[]),
         )
 
         with pytest.raises(KafkaBrokersNotConfigured, match="No Kafka brokers configured"):
@@ -138,7 +217,7 @@ class TestKafkaProducerContextManager:
         fake = FakeKafkaProducer()
         mocker.patch(
             "notificator.kafka.NotificatorSettings.create",
-            return_value=self._make_settings(dev=True, bootstrap_servers=["broker:9092"], topic="my-topic"),
+            return_value=_make_settings(dev=True, bootstrap_servers=["broker:9092"], topic="my-topic"),
         )
         mocker.patch("notificator.kafka._build_producer", return_value=fake)
         mocker.patch("notificator.kafka.KAFKA_RETRY_INTERVAL", 0)
@@ -155,7 +234,7 @@ class TestKafkaProducerContextManager:
         fake = FakeKafkaProducer()
         mocker.patch(
             "notificator.kafka.NotificatorSettings.create",
-            return_value=self._make_settings(dev=True, bootstrap_servers=["broker:9092"]),
+            return_value=_make_settings(dev=True, bootstrap_servers=["broker:9092"]),
         )
         mocker.patch("notificator.kafka._build_producer", return_value=fake)
         mocker.patch("notificator.kafka.KAFKA_RETRY_INTERVAL", 0)


### PR DESCRIPTION
The notificator admin endpoints failed with a `KafkaConnectionError` on stage because the cluster there requires TLS. The `AIOKafkaProducer` was being constructed with only `bootstrap_servers`, so the TCP connection was made but the TLS handshake never happened. `NotificatorSettings` already exposed `tls_cert_path` and `tls_key_path`, but those paths were never wired into the producer.

On this PR:
- Added `_build_ssl_context(settings)`: checks whether both the cert and key files exist on disk and, if so, creates an `ssl.SSLContext` with `load_cert_chain`. Returns `None` when the files are absent (local dev), so the plain connection path is preserved.