### PR TITLE
[RSPEED-2874] Usa Kafka CA instead our TLS CA

### DIFF
--- a/src/notificator/kafka.py
+++ b/src/notificator/kafka.py
@@ -71,7 +71,7 @@ def _build_producer(settings: NotificatorSettings) -> AIOKafkaProducer:
         bootstrap_servers=settings.bootstrap_servers,  # pyright: ignore [reportArgumentType]
         security_protocol=security_protocol,
         ssl_context=ssl_context,
-        sasl_mechanism=settings.kafka_sasl_mechanism,
+        sasl_mechanism=settings.kafka_sasl_mechanism,  # pyright: ignore [reportArgumentType]
         sasl_plain_username=settings.kafka_sasl_username,
         sasl_plain_password=settings.kafka_sasl_password,
     )

--- a/src/notificator/kafka.py
+++ b/src/notificator/kafka.py
@@ -23,12 +23,12 @@ import ssl
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from pathlib import Path
 
 import structlog
 
 from aiokafka import AIOKafkaProducer
 from aiokafka.errors import KafkaError
+from aiokafka.helpers import create_ssl_context
 
 from notificator.notificator_config import KAFKA_MAX_RETRIES
 from notificator.notificator_config import KAFKA_RETRY_INTERVAL
@@ -43,36 +43,38 @@ class KafkaBrokersNotConfigured(Exception):
 
 
 def _build_ssl_context(settings: NotificatorSettings) -> ssl.SSLContext | None:
-    """Return an mTLS SSLContext if the TLS cert and key files are present, else None.
+    """Return an SSLContext for Kafka broker verification, or None if no CA cert is configured.
 
-    In Clowder-managed environments (stage/prod) the cert and key are mounted
-    at the paths from settings. In local dev the files are absent, so we skip
-    SSL and fall back to a plain connection.
+    Uses ``aiokafka.helpers.create_ssl_context`` (the canonical aiokafka helper)
+    with the broker CA certificate provided by Clowder.  Returns ``None`` in
+    local dev where no CA cert is configured.
     """
-    cert = Path(settings.tls_cert_path)
-    key = Path(settings.tls_key_path)
-    if not cert.exists() or not key.exists():
+    ca_path = settings.kafka_ca_path
+    if not ca_path:
         return None
-    ssl_context = ssl.create_default_context()
-    ssl_context.load_cert_chain(certfile=str(cert), keyfile=str(key))
-    logger.info("Kafka SSL context created")
-    return ssl_context
+    ctx = create_ssl_context(cafile=ca_path)
+    logger.info("Kafka SSL context created", ca_path=ca_path)
+    return ctx
 
 
 def _build_producer(settings: NotificatorSettings) -> AIOKafkaProducer:
     """Create an AIOKafkaProducer from the notificator settings.
 
-    Uses mTLS when TLS cert/key files are present (stage/prod Clowder mounts),
-    otherwise connects without SSL (local dev).
+    Security protocol is derived from the Clowder broker authtype:
+    - ``SASL_SSL``: MSK with SASL/SCRAM auth (stage/prod, port 9096)
+    - ``PLAINTEXT``: local dev (no Clowder config)
     """
     ssl_context = _build_ssl_context(settings)
-    if ssl_context:
-        return AIOKafkaProducer(
-            bootstrap_servers=settings.bootstrap_servers,  # pyright: ignore [reportArgumentType]
-            security_protocol="SSL",
-            ssl_context=ssl_context,
-        )
-    return AIOKafkaProducer(bootstrap_servers=settings.bootstrap_servers)  # pyright: ignore [reportArgumentType]
+    security_protocol = settings.kafka_security_protocol
+    logger.info("Building Kafka producer", security_protocol=security_protocol)
+    return AIOKafkaProducer(
+        bootstrap_servers=settings.bootstrap_servers,  # pyright: ignore [reportArgumentType]
+        security_protocol=security_protocol,
+        ssl_context=ssl_context,
+        sasl_mechanism=settings.kafka_sasl_mechanism,
+        sasl_plain_username=settings.kafka_sasl_username,
+        sasl_plain_password=settings.kafka_sasl_password,
+    )
 
 
 async def _start_producer(producer: AIOKafkaProducer) -> None:

--- a/src/notificator/notificator_config.py
+++ b/src/notificator/notificator_config.py
@@ -15,8 +15,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from app_common_python import isClowderEnabled
 from app_common_python import KafkaServers
 from app_common_python import KafkaTopics
+from app_common_python import LoadedConfig
+from app_common_python.types import BrokerConfigAuthtypeEnum
 
 from roadmap.config import Settings
 
@@ -73,6 +76,64 @@ class NotificatorSettings(Settings):
         separate cache entries automatically.
         """
         return super().create()  # type: ignore[return-value]
+
+    def _kafka_broker(self):
+        """Return the first Clowder Kafka broker config, or None if not available."""
+        if isClowderEnabled() and LoadedConfig and LoadedConfig.kafka:
+            brokers = LoadedConfig.kafka.brokers or []
+            if brokers:
+                return brokers[0]
+        return None
+
+    @property
+    def kafka_ca_path(self) -> str | None:
+        """Path to the Kafka broker CA certificate for TLS verification.
+
+        When running under Clowder and the broker config includes a CA cert,
+        ``SmartAppConfig.kafka_ca()`` writes it to a temp file and returns the path.
+        Returns ``None`` in dev mode or when no CA cert is configured.
+        """
+        broker = self._kafka_broker()
+        if broker and broker.cacert:
+            return LoadedConfig.kafka_ca()
+        return None
+
+    @property
+    def kafka_security_protocol(self) -> str:
+        """Kafka security protocol derived from the Clowder broker authtype.
+
+        ``BrokerConfigAuthtypeEnum`` only defines ``SASL``, so in practice this
+        returns either ``"SASL_SSL"`` (stage/prod MSK on port 9096) or
+        ``"PLAINTEXT"`` (local dev without a Clowder config).
+        """
+        broker = self._kafka_broker()
+        if broker and broker.authtype == BrokerConfigAuthtypeEnum.SASL:
+            return "SASL_SSL"
+        return "PLAINTEXT"
+
+    @property
+    def kafka_sasl_mechanism(self) -> str | None:
+        """SASL mechanism from the Clowder broker config (e.g. ``"SCRAM-SHA-512"``)."""
+        broker = self._kafka_broker()
+        if broker and broker.sasl and broker.sasl.saslMechanism:
+            return broker.sasl.saslMechanism.upper()
+        return None
+
+    @property
+    def kafka_sasl_username(self) -> str | None:
+        """SASL username from the Clowder broker config."""
+        broker = self._kafka_broker()
+        if broker and broker.sasl:
+            return broker.sasl.username
+        return None
+
+    @property
+    def kafka_sasl_password(self) -> str | None:
+        """SASL password from the Clowder broker config."""
+        broker = self._kafka_broker()
+        if broker and broker.sasl:
+            return broker.sasl.password
+        return None
 
     @property
     def bootstrap_servers(self) -> list[str]:

--- a/src/notificator/notificator_config.py
+++ b/src/notificator/notificator_config.py
@@ -94,7 +94,7 @@ class NotificatorSettings(Settings):
         Returns ``None`` in dev mode or when no CA cert is configured.
         """
         broker = self._kafka_broker()
-        if broker and broker.cacert:
+        if broker and broker.cacert and LoadedConfig:
             return LoadedConfig.kafka_ca()
         return None
 

--- a/tests/notificator/test_kafka.py
+++ b/tests/notificator/test_kafka.py
@@ -27,83 +27,96 @@ def _make_settings(
     *,
     dev=False,
     bootstrap_servers=None,
-    tls_cert_path="/tmp/tls/cert.pem",
-    tls_key_path="/tmp/tls/key.pem",
+    kafka_ca_path=None,
+    kafka_security_protocol="PLAINTEXT",
+    kafka_sasl_mechanism=None,
+    kafka_sasl_username=None,
+    kafka_sasl_password=None,
     topic="test-topic",
 ):
     return SimpleNamespace(
         dev=dev,
         bootstrap_servers=["broker:9092"] if bootstrap_servers is None else bootstrap_servers,
-        tls_cert_path=tls_cert_path,
-        tls_key_path=tls_key_path,
+        kafka_ca_path=kafka_ca_path,
+        kafka_security_protocol=kafka_security_protocol,
+        kafka_sasl_mechanism=kafka_sasl_mechanism,
+        kafka_sasl_username=kafka_sasl_username,
+        kafka_sasl_password=kafka_sasl_password,
         notifications_topic=topic,
     )
 
 
 class TestBuildSSLContext:
-    """_build_ssl_context: returns an SSLContext only when both cert and key files exist."""
+    """_build_ssl_context: returns an SSLContext only when a Kafka CA cert path is available."""
 
-    def test_returns_none_when_cert_missing(self, tmp_path):
-        """No cert file → no SSL context (plain connection, e.g. local dev)."""
-        settings = _make_settings(
-            tls_cert_path=str(tmp_path / "missing_cert.pem"),
-            tls_key_path=str(tmp_path / "missing_key.pem"),
-        )
+    def test_returns_none_when_no_ca_path(self):
+        """No CA path (local dev / Clowder without Kafka TLS) → no SSL context."""
+        settings = _make_settings(kafka_ca_path=None)
         assert _build_ssl_context(settings) is None
 
-    def test_returns_none_when_key_missing(self, tmp_path):
-        """Cert present but key absent → no SSL context."""
-        cert = tmp_path / "cert.pem"
-        cert.write_text("cert-data")
-        settings = _make_settings(
-            tls_cert_path=str(cert),
-            tls_key_path=str(tmp_path / "missing_key.pem"),
-        )
-        assert _build_ssl_context(settings) is None
-
-    def test_returns_ssl_context_when_both_files_exist(self, tmp_path, mocker):
-        """Both files present → returns an ssl.SSLContext with the cert loaded."""
-        cert = tmp_path / "cert.pem"
-        key = tmp_path / "key.pem"
-        cert.write_text("cert-data")
-        key.write_text("key-data")
+    def test_returns_ssl_context_when_ca_path_provided(self, mocker):
+        """CA path present → delegates to aiokafka create_ssl_context with cafile."""
         mock_ctx = mocker.MagicMock(spec=ssl.SSLContext)
-        mocker.patch("ssl.create_default_context", return_value=mock_ctx)
-        settings = _make_settings(tls_cert_path=str(cert), tls_key_path=str(key))
+        mock_create = mocker.patch("notificator.kafka.create_ssl_context", return_value=mock_ctx)
+        settings = _make_settings(kafka_ca_path="/tmp/kafka-ca.pem")
 
         result = _build_ssl_context(settings)
 
         assert result is mock_ctx
-        mock_ctx.load_cert_chain.assert_called_once_with(certfile=str(cert), keyfile=str(key))
+        mock_create.assert_called_once_with(cafile="/tmp/kafka-ca.pem")
 
 
 class TestBuildProducer:
-    """_build_producer: wires SSL context into the producer when TLS files are present."""
+    """_build_producer: wires full security config into the producer from settings."""
 
-    def test_uses_ssl_when_context_available(self, mocker):
-        """When _build_ssl_context returns a context, the producer is built with SSL."""
+    def test_sasl_ssl_protocol_passes_all_security_params(self, mocker):
+        """SASL_SSL path (MSK stage/prod): security_protocol, ssl_context, and SASL
+        credentials must all be forwarded to AIOKafkaProducer."""
         mock_ctx = mocker.MagicMock(spec=ssl.SSLContext)
         mocker.patch("notificator.kafka._build_ssl_context", return_value=mock_ctx)
         mock_producer_cls = mocker.patch("notificator.kafka.AIOKafkaProducer")
-        settings = _make_settings(bootstrap_servers=["broker:9096"])
+        settings = _make_settings(
+            bootstrap_servers=["broker:9096"],
+            kafka_ca_path="/tmp/kafka-ca.pem",
+            kafka_security_protocol="SASL_SSL",
+            kafka_sasl_mechanism="SCRAM-SHA-512",
+            kafka_sasl_username="user",
+            kafka_sasl_password="secret",
+        )
 
         _build_producer(settings)
 
         mock_producer_cls.assert_called_once_with(
             bootstrap_servers=["broker:9096"],
-            security_protocol="SSL",
+            security_protocol="SASL_SSL",
             ssl_context=mock_ctx,
+            sasl_mechanism="SCRAM-SHA-512",
+            sasl_plain_username="user",
+            sasl_plain_password="secret",
         )
 
-    def test_no_ssl_when_context_is_none(self, mocker):
-        """When _build_ssl_context returns None, the producer is built without SSL."""
+    def test_plaintext_protocol_no_ssl_no_sasl(self, mocker):
+        """PLAINTEXT path (local dev): no SSL context, no SASL credentials."""
         mocker.patch("notificator.kafka._build_ssl_context", return_value=None)
         mock_producer_cls = mocker.patch("notificator.kafka.AIOKafkaProducer")
-        settings = _make_settings(bootstrap_servers=["localhost:9092"])
+        settings = _make_settings(
+            bootstrap_servers=["localhost:9092"],
+            kafka_security_protocol="PLAINTEXT",
+            kafka_sasl_mechanism=None,
+            kafka_sasl_username=None,
+            kafka_sasl_password=None,
+        )
 
         _build_producer(settings)
 
-        mock_producer_cls.assert_called_once_with(bootstrap_servers=["localhost:9092"])
+        mock_producer_cls.assert_called_once_with(
+            bootstrap_servers=["localhost:9092"],
+            security_protocol="PLAINTEXT",
+            ssl_context=None,
+            sasl_mechanism=None,
+            sasl_plain_username=None,
+            sasl_plain_password=None,
+        )
 
 
 class TestKafkaProducer:

--- a/tests/notificator/test_notificator_config.py
+++ b/tests/notificator/test_notificator_config.py
@@ -1,6 +1,22 @@
+from types import SimpleNamespace
+
 from notificator.notificator_config import DEV_BOOTSTRAP_SERVERS
 from notificator.notificator_config import NOTIFICATIONS_TOPIC_REQUESTED
 from notificator.notificator_config import NotificatorSettings
+
+
+def _patch_clowder_broker(mocker, *, cacert=None, authtype=None, sasl=None):
+    """Patch isClowderEnabled and LoadedConfig to simulate a single Clowder broker.
+
+    Returns ``(broker, mock_config)`` so callers can configure ``mock_config.kafka_ca``
+    or inspect other attributes as needed.
+    """
+    broker = SimpleNamespace(cacert=cacert, authtype=authtype, sasl=sasl)
+    mock_config = mocker.MagicMock()
+    mock_config.kafka.brokers = [broker]
+    mocker.patch("notificator.notificator_config.isClowderEnabled", return_value=True)
+    mocker.patch("notificator.notificator_config.LoadedConfig", mock_config)
+    return broker, mock_config
 
 
 def test_create_returns_notificator_settings():
@@ -94,3 +110,164 @@ def test_inherits_base_settings():
         settings.database_url.encoded_string()
         == "postgresql+psycopg://postgres:postgres@localhost:5432/digital_roadmap"
     )
+
+
+class TestKafkaBroker:
+    """_kafka_broker: Clowder broker resolution edge-cases."""
+
+    def test_returns_none_when_clowder_disabled(self, mocker):
+        """No Clowder at all → _kafka_broker returns None."""
+        mocker.patch("notificator.notificator_config.isClowderEnabled", return_value=False)
+        settings = NotificatorSettings.create()
+        assert settings._kafka_broker() is None
+
+    def test_returns_none_when_kafka_brokers_list_is_empty(self, mocker):
+        """Clowder is active but the brokers list is empty → _kafka_broker returns None."""
+        mock_config = mocker.MagicMock()
+        mock_config.kafka.brokers = []
+        mocker.patch("notificator.notificator_config.isClowderEnabled", return_value=True)
+        mocker.patch("notificator.notificator_config.LoadedConfig", mock_config)
+
+        settings = NotificatorSettings.create()
+
+        assert settings._kafka_broker() is None
+
+    def test_returns_first_broker_when_clowder_configured(self, mocker):
+        """Clowder provides brokers → first one is returned."""
+        _, mock_config = _patch_clowder_broker(mocker, cacert=None)
+        first_broker = mock_config.kafka.brokers[0]
+
+        settings = NotificatorSettings.create()
+
+        assert settings._kafka_broker() is first_broker
+
+
+class TestKafkaCaPath:
+    """kafka_ca_path: CA certificate path resolution."""
+
+    def test_returns_none_when_no_broker(self, mocker):
+        """No Clowder broker configured → no CA path."""
+        mocker.patch("notificator.notificator_config.isClowderEnabled", return_value=False)
+        settings = NotificatorSettings.create()
+        assert settings.kafka_ca_path is None
+
+    def test_returns_none_when_broker_has_no_cacert(self, mocker):
+        """Broker present but cacert is falsy → no CA path."""
+        _patch_clowder_broker(mocker, cacert=None)
+        settings = NotificatorSettings.create()
+        assert settings.kafka_ca_path is None
+
+    def test_returns_path_when_broker_has_cacert(self, mocker):
+        """Broker with a CA cert → LoadedConfig.kafka_ca() result is returned."""
+        _, mock_config = _patch_clowder_broker(mocker, cacert="-----BEGIN CERTIFICATE-----")
+        mock_config.kafka_ca.return_value = "/tmp/kafka-ca.pem"
+
+        settings = NotificatorSettings.create()
+
+        assert settings.kafka_ca_path == "/tmp/kafka-ca.pem"
+        mock_config.kafka_ca.assert_called_once()
+
+    def test_returns_none_when_loaded_config_is_none_despite_broker_cacert(self, mocker):
+        """Defensive branch: even if _kafka_broker() returns a broker with a cacert,
+        a None LoadedConfig must not cause an AttributeError — returns None instead."""
+        broker = SimpleNamespace(cacert="cert-content")
+        mocker.patch.object(NotificatorSettings, "_kafka_broker", return_value=broker)
+        mocker.patch("notificator.notificator_config.LoadedConfig", None)
+
+        settings = NotificatorSettings.create()
+
+        assert settings.kafka_ca_path is None
+
+
+class TestKafkaSecurityProtocol:
+    """kafka_security_protocol: PLAINTEXT vs SASL_SSL detection."""
+
+    def test_returns_plaintext_when_no_broker(self, mocker):
+        """No Clowder broker → fall back to PLAINTEXT (local dev)."""
+        mocker.patch("notificator.notificator_config.isClowderEnabled", return_value=False)
+        settings = NotificatorSettings.create()
+        assert settings.kafka_security_protocol == "PLAINTEXT"
+
+    def test_returns_sasl_ssl_for_sasl_broker(self, mocker):
+        """Broker with SASL authtype → SASL_SSL protocol."""
+        sasl_enum = mocker.patch("notificator.notificator_config.BrokerConfigAuthtypeEnum")
+        sasl_sentinel = object()
+        sasl_enum.SASL = sasl_sentinel
+        _patch_clowder_broker(mocker, authtype=sasl_sentinel)
+
+        settings = NotificatorSettings.create()
+
+        assert settings.kafka_security_protocol == "SASL_SSL"
+
+    def test_returns_plaintext_for_non_sasl_broker(self, mocker):
+        """Broker present but authtype is not SASL → still PLAINTEXT."""
+        _patch_clowder_broker(mocker, authtype=None)
+        settings = NotificatorSettings.create()
+        assert settings.kafka_security_protocol == "PLAINTEXT"
+
+
+class TestKafkaSaslProperties:
+    """kafka_sasl_mechanism / username / password: SASL credential resolution."""
+
+    def test_sasl_mechanism_returns_none_when_no_broker(self, mocker):
+        mocker.patch("notificator.notificator_config.isClowderEnabled", return_value=False)
+        settings = NotificatorSettings.create()
+        assert settings.kafka_sasl_mechanism is None
+
+    def test_sasl_mechanism_returns_none_when_broker_has_no_sasl(self, mocker):
+        _patch_clowder_broker(mocker, sasl=None)
+        settings = NotificatorSettings.create()
+        assert settings.kafka_sasl_mechanism is None
+
+    def test_sasl_mechanism_returns_uppercased_value(self, mocker):
+        """Mechanism from Clowder is uppercased to match the aiokafka expectation."""
+        sasl = SimpleNamespace(saslMechanism="scram-sha-512", username="u", password="p")
+        _patch_clowder_broker(mocker, sasl=sasl)
+
+        settings = NotificatorSettings.create()
+
+        assert settings.kafka_sasl_mechanism == "SCRAM-SHA-512"
+
+    def test_sasl_mechanism_returns_none_when_sasl_mechanism_is_falsy(self, mocker):
+        sasl = SimpleNamespace(saslMechanism=None, username="u", password="p")
+        _patch_clowder_broker(mocker, sasl=sasl)
+
+        settings = NotificatorSettings.create()
+
+        assert settings.kafka_sasl_mechanism is None
+
+    def test_sasl_username_returns_none_when_no_broker(self, mocker):
+        mocker.patch("notificator.notificator_config.isClowderEnabled", return_value=False)
+        settings = NotificatorSettings.create()
+        assert settings.kafka_sasl_username is None
+
+    def test_sasl_username_returns_none_when_broker_has_no_sasl(self, mocker):
+        _patch_clowder_broker(mocker, sasl=None)
+        settings = NotificatorSettings.create()
+        assert settings.kafka_sasl_username is None
+
+    def test_sasl_username_returns_username_when_configured(self, mocker):
+        sasl = SimpleNamespace(saslMechanism="SCRAM-SHA-512", username="kafka-user", password="x")
+        _patch_clowder_broker(mocker, sasl=sasl)
+
+        settings = NotificatorSettings.create()
+
+        assert settings.kafka_sasl_username == "kafka-user"
+
+    def test_sasl_password_returns_none_when_no_broker(self, mocker):
+        mocker.patch("notificator.notificator_config.isClowderEnabled", return_value=False)
+        settings = NotificatorSettings.create()
+        assert settings.kafka_sasl_password is None
+
+    def test_sasl_password_returns_none_when_broker_has_no_sasl(self, mocker):
+        _patch_clowder_broker(mocker, sasl=None)
+        settings = NotificatorSettings.create()
+        assert settings.kafka_sasl_password is None
+
+    def test_sasl_password_returns_password_when_configured(self, mocker):
+        sasl = SimpleNamespace(saslMechanism="SCRAM-SHA-512", username="u", password="s3cr3t")
+        _patch_clowder_broker(mocker, sasl=sasl)
+
+        settings = NotificatorSettings.create()
+
+        assert settings.kafka_sasl_password == "s3cr3t"


### PR DESCRIPTION
Switches the Kafka TLS configuration from mutual TLS (mTLS) — where the client presents its own cert/key — to one-way TLS using only the broker's CA certificate, combined with SASL/SCRAM for authentication. This matches how MSK is actually configured in stage/prod via Clowder.

**Before**: the producer looked for a client cert+key pair mounted by Clowder and used `security_protocol="SSL"` with `ssl.create_default_context()`.

**After**: the producer reads the Clowder broker config to determine:
- The CA cert path (`kafka_ca()`) for TLS broker verification, delegating to `aiokafka.helpers.create_ssl_context`
- The security protocol (`SASL_SSL` for MSK, `PLAINTEXT` for local dev)
- SASL credentials (mechanism, username, password) from the Clowder broker SASL config
