### PR TITLE
SSL context error

### DIFF
--- a/src/notificator/notificator_config.py
+++ b/src/notificator/notificator_config.py
@@ -105,10 +105,18 @@ class NotificatorSettings(Settings):
         ``BrokerConfigAuthtypeEnum`` only defines ``SASL``, so in practice this
         returns either ``"SASL_SSL"`` (stage/prod MSK on port 9096) or
         ``"PLAINTEXT"`` (local dev without a Clowder config).
+
+        When SASL auth is configured, SSL is required and a CA cert must be present.
+        Falls back to ``"SASL_PLAINTEXT"`` if SASL is configured without a CA cert
+        (though this is an unusual configuration).
         """
         broker = self._kafka_broker()
         if broker and broker.authtype == BrokerConfigAuthtypeEnum.SASL:
-            return "SASL_SSL"
+            # SASL_SSL requires a CA certificate for TLS
+            if broker.cacert:
+                return "SASL_SSL"
+            # Fallback for SASL without TLS (unusual but valid)
+            return "SASL_PLAINTEXT"
         return "PLAINTEXT"
 
     @property

--- a/tests/notificator/test_notificator_config.py
+++ b/tests/notificator/test_notificator_config.py
@@ -188,12 +188,12 @@ class TestKafkaSecurityProtocol:
         settings = NotificatorSettings.create()
         assert settings.kafka_security_protocol == "PLAINTEXT"
 
-    def test_returns_sasl_ssl_for_sasl_broker(self, mocker):
-        """Broker with SASL authtype → SASL_SSL protocol."""
+    def test_returns_sasl_ssl_for_sasl_broker_with_cacert(self, mocker):
+        """Broker with SASL authtype and CA cert → SASL_SSL protocol."""
         sasl_enum = mocker.patch("notificator.notificator_config.BrokerConfigAuthtypeEnum")
         sasl_sentinel = object()
         sasl_enum.SASL = sasl_sentinel
-        _patch_clowder_broker(mocker, authtype=sasl_sentinel)
+        _patch_clowder_broker(mocker, authtype=sasl_sentinel, cacert="-----BEGIN CERTIFICATE-----")
 
         settings = NotificatorSettings.create()
 
@@ -204,6 +204,17 @@ class TestKafkaSecurityProtocol:
         _patch_clowder_broker(mocker, authtype=None)
         settings = NotificatorSettings.create()
         assert settings.kafka_security_protocol == "PLAINTEXT"
+
+    def test_returns_sasl_plaintext_when_sasl_without_cacert(self, mocker):
+        """SASL authtype but no CA cert → SASL_PLAINTEXT (prevents SSL context error)."""
+        sasl_enum = mocker.patch("notificator.notificator_config.BrokerConfigAuthtypeEnum")
+        sasl_sentinel = object()
+        sasl_enum.SASL = sasl_sentinel
+        _patch_clowder_broker(mocker, authtype=sasl_sentinel, cacert=None)
+
+        settings = NotificatorSettings.create()
+
+        assert settings.kafka_security_protocol == "SASL_PLAINTEXT"
 
 
 class TestKafkaSaslProperties:


### PR DESCRIPTION
When SASL authentication is configured but no CA certificate is available, the code was setting security_protocol="SASL_SSL" while ssl_context=None, which caused aiokafka to raise:

ValueError: `ssl_context` is mandatory if security_protocol=='SSL'

Solution: Modified [notificator_config.py:102-120](vscode-webview://07i2unioprqbv7ptqbmmqnpseb0gnhs0khrbl3e2mrg70ttmvrp9/src/notificator/notificator_config.py#L102-L120) to check if a CA certificate exists before returning "SASL_SSL". Now:

SASL with CA cert → "SASL_SSL" (secure, with TLS)
SASL without CA cert → "SASL_PLAINTEXT" (fallback, prevents error)
No SASL → "PLAINTEXT" (local dev)