### PR TITLE
Report date field

### DIFF
--- a/src/notificator/notificator.py
+++ b/src/notificator/notificator.py
@@ -169,6 +169,7 @@ class Notificator:
             appstream_grouped=appstream_grouped,
             org_id=str(self.org_id),
             event_type="retiring-lifecycle-monthly-report",
+            application="life-cycle",
         )
 
         logger.info("Built lifecycle notification", org_id=self.org_id, event_type="retiring-lifecycle-monthly-report")
@@ -181,7 +182,7 @@ def _build_notification_payload(
     org_id: str,
     event_type: str,
     bundle: str = "rhel",
-    application: str = "planning",
+    application: str = "life-cycle",
 ) -> dict:
     """Build kafka message for notification backend using their specified format.
 
@@ -191,10 +192,15 @@ def _build_notification_payload(
             "version": "v1.0.0",
             "id": "db6e6cee-...",
             "bundle": "rhel",
-            "application": "planning",
+            "application": "life-cycle",
             "event_type": "retiring-lifecycle-monthly-report",
             "timestamp": "2026-02-24T12:00:00Z",
             "org_id": "1234",
+            "context": {
+                "lifecycle": {
+                    "report_date": "February 2026"
+                }
+            },
             "events": [{
                 "metadata": {},
                 "payload": {
@@ -213,15 +219,23 @@ def _build_notification_payload(
             "recipients": [],
         }
     """
+    now = datetime.now(UTC)
+    timestamp = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    report_date = now.strftime("%B %Y")  # e.g., "May 2026"
+
     return {
         "version": "v1.0.0",
         "id": str(uuid4()),
         "bundle": bundle,
         "application": application,
         "event_type": event_type,
-        "timestamp": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),  # or we can use datetime.now(UTC).isoformat()
+        "timestamp": timestamp,
         "org_id": org_id,
-        "context": {},
+        "context": {
+            application.replace("-", ""): {
+                "report_date": report_date,
+            }
+        },
         "events": [
             {
                 "metadata": {},

--- a/tests/notificator/test_notificator.py
+++ b/tests/notificator/test_notificator.py
@@ -282,16 +282,17 @@ class TestNotificator:
             appstream_grouped=appstream,
             org_id=str(ORG_ID),
             event_type="retiring-lifecycle-monthly-report",
+            application="life-cycle",
         )
 
         assert result["version"] == "v1.0.0"
         assert result["id"] == str(FIXED_UUID)
         assert result["bundle"] == "rhel"
-        assert result["application"] == "planning"
+        assert result["application"] == "life-cycle"
         assert result["event_type"] == "retiring-lifecycle-monthly-report"
         assert result["timestamp"] == FIXED_TIMESTAMP
         assert result["org_id"] == str(ORG_ID)
-        assert result["context"] == {}
+        assert result["context"] == {"lifecycle": {"report_date": "March 2026"}}
         assert result["recipients"] == []
         assert len(result["events"]) == 1
         assert result["events"][0]["payload"] == {**rhel, **appstream}
@@ -303,8 +304,10 @@ class TestNotificator:
             appstream_grouped=EMPTY_APPSTREAM_SECTIONS,
             org_id=str(ORG_ID),
             event_type="retiring-lifecycle-monthly-report",
+            application="life-cycle",
         )
 
         assert len(result["events"]) == 1
         assert result["events"][0]["payload"] == {**EMPTY_RHEL_SECTIONS, **EMPTY_APPSTREAM_SECTIONS}
         assert result["events"][0]["metadata"] == {}
+        assert result["context"] == {"lifecycle": {"report_date": "March 2026"}}


### PR DESCRIPTION
## Summary

Add `report_date` field to lifecycle notification context to display the month and year of the notification report.

## Changes

- Add `report_date` field to notification context, formatted as "Month YYYY" (e.g., "May 2026")
- Update application identifier from "planning" to "life-cycle" to match notification backend requirements
- The report date is derived from the notification timestamp and added to the context under the `lifecycle` key

## Payload Structure

The notification payload now includes:

```json
{
  "context": {
    "lifecycle": {
      "report_date": "May 2026"
    }
  }
}
