### PR TITLE
[RSPEED-2874] Fix Kafka SSL connection to MSK brokers

### DIFF
--- a/src/notificator/kafka.py
+++ b/src/notificator/kafka.py
@@ -43,17 +43,17 @@ class KafkaBrokersNotConfigured(Exception):
 
 
 def _build_ssl_context(settings: NotificatorSettings) -> ssl.SSLContext | None:
-    """Return an SSLContext for Kafka broker verification, or None if no CA cert is configured.
+    """Return an SSLContext for Kafka broker TLS, or ``None`` for PLAINTEXT.
 
-    Uses ``aiokafka.helpers.create_ssl_context`` (the canonical aiokafka helper)
-    with the broker CA certificate provided by Clowder.  Returns ``None`` in
-    local dev where no CA cert is configured.
+    When a Clowder-provided broker CA cert exists (``kafka_ca_path``), it is
+    loaded as the sole trust anchor.  When SASL auth is configured but no
+    custom CA is provided, ``create_ssl_context(cafile=None)`` falls back to
+    the system trust store (which includes the Amazon root CA used by MSK).
     """
-    ca_path = settings.kafka_ca_path
-    if not ca_path:
+    if settings.kafka_security_protocol != "SASL_SSL":
         return None
-    ctx = create_ssl_context(cafile=ca_path)
-    logger.info("Kafka SSL context created", ca_path=ca_path)
+    ctx = create_ssl_context(cafile=settings.kafka_ca_path)
+    logger.info("Kafka SSL context created", ca_path=settings.kafka_ca_path or "(system trust store)")
     return ctx
 
 

--- a/src/notificator/notificator_config.py
+++ b/src/notificator/notificator_config.py
@@ -102,21 +102,13 @@ class NotificatorSettings(Settings):
     def kafka_security_protocol(self) -> str:
         """Kafka security protocol derived from the Clowder broker authtype.
 
-        ``BrokerConfigAuthtypeEnum`` only defines ``SASL``, so in practice this
-        returns either ``"SASL_SSL"`` (stage/prod MSK on port 9096) or
-        ``"PLAINTEXT"`` (local dev without a Clowder config).
-
-        When SASL auth is configured, SSL is required and a CA cert must be present.
-        Falls back to ``"SASL_PLAINTEXT"`` if SASL is configured without a CA cert
-        (though this is an unusual configuration).
+        Returns ``"SASL_SSL"`` when the broker uses SASL auth (stage/prod MSK
+        on port 9096) or ``"PLAINTEXT"`` when no Clowder broker is configured
+        (local dev).
         """
         broker = self._kafka_broker()
         if broker and broker.authtype == BrokerConfigAuthtypeEnum.SASL:
-            # SASL_SSL requires a CA certificate for TLS
-            if broker.cacert:
-                return "SASL_SSL"
-            # Fallback for SASL without TLS (unusual but valid)
-            return "SASL_PLAINTEXT"
+            return "SASL_SSL"
         return "PLAINTEXT"
 
     @property

--- a/tests/notificator/test_kafka.py
+++ b/tests/notificator/test_kafka.py
@@ -47,23 +47,37 @@ def _make_settings(
 
 
 class TestBuildSSLContext:
-    """_build_ssl_context: returns an SSLContext only when a Kafka CA cert path is available."""
+    """_build_ssl_context: returns an SSLContext when security protocol requires SSL."""
 
-    def test_returns_none_when_no_ca_path(self):
-        """No CA path (local dev / Clowder without Kafka TLS) → no SSL context."""
-        settings = _make_settings(kafka_ca_path=None)
+    def test_returns_none_when_plaintext(self):
+        """PLAINTEXT protocol (local dev) → no SSL context needed."""
+        settings = _make_settings(kafka_ca_path=None, kafka_security_protocol="PLAINTEXT")
         assert _build_ssl_context(settings) is None
 
-    def test_returns_ssl_context_when_ca_path_provided(self, mocker):
-        """CA path present → delegates to aiokafka create_ssl_context with cafile."""
+    def test_returns_ssl_context_with_ca_path(self, mocker):
+        """SASL_SSL with CA path → delegates to aiokafka create_ssl_context with cafile."""
         mock_ctx = mocker.MagicMock(spec=ssl.SSLContext)
         mock_create = mocker.patch("notificator.kafka.create_ssl_context", return_value=mock_ctx)
-        settings = _make_settings(kafka_ca_path="/tmp/kafka-ca.pem")
+        settings = _make_settings(
+            kafka_ca_path="/tmp/kafka-ca.pem",
+            kafka_security_protocol="SASL_SSL",
+        )
 
         result = _build_ssl_context(settings)
 
         assert result is mock_ctx
         mock_create.assert_called_once_with(cafile="/tmp/kafka-ca.pem")
+
+    def test_returns_ssl_context_with_system_cas_when_no_ca_path(self, mocker):
+        """SASL_SSL without custom CA → uses system trust store (covers MSK certs)."""
+        mock_ctx = mocker.MagicMock(spec=ssl.SSLContext)
+        mock_create = mocker.patch("notificator.kafka.create_ssl_context", return_value=mock_ctx)
+        settings = _make_settings(kafka_ca_path=None, kafka_security_protocol="SASL_SSL")
+
+        result = _build_ssl_context(settings)
+
+        assert result is mock_ctx
+        mock_create.assert_called_once_with(cafile=None)
 
 
 class TestBuildProducer:

--- a/tests/notificator/test_notificator_config.py
+++ b/tests/notificator/test_notificator_config.py
@@ -189,7 +189,7 @@ class TestKafkaSecurityProtocol:
         assert settings.kafka_security_protocol == "PLAINTEXT"
 
     def test_returns_sasl_ssl_for_sasl_broker_with_cacert(self, mocker):
-        """Broker with SASL authtype and CA cert → SASL_SSL protocol."""
+        """Broker with SASL authtype and CA cert → SASL_SSL."""
         sasl_enum = mocker.patch("notificator.notificator_config.BrokerConfigAuthtypeEnum")
         sasl_sentinel = object()
         sasl_enum.SASL = sasl_sentinel
@@ -205,8 +205,8 @@ class TestKafkaSecurityProtocol:
         settings = NotificatorSettings.create()
         assert settings.kafka_security_protocol == "PLAINTEXT"
 
-    def test_returns_sasl_plaintext_when_sasl_without_cacert(self, mocker):
-        """SASL authtype but no CA cert → SASL_PLAINTEXT (prevents SSL context error)."""
+    def test_returns_sasl_ssl_when_sasl_without_cacert(self, mocker):
+        """SASL authtype without CA cert → still SASL_SSL (system trust store covers MSK)."""
         sasl_enum = mocker.patch("notificator.notificator_config.BrokerConfigAuthtypeEnum")
         sasl_sentinel = object()
         sasl_enum.SASL = sasl_sentinel
@@ -214,7 +214,7 @@ class TestKafkaSecurityProtocol:
 
         settings = NotificatorSettings.create()
 
-        assert settings.kafka_security_protocol == "SASL_PLAINTEXT"
+        assert settings.kafka_security_protocol == "SASL_SSL"
 
 
 class TestKafkaSaslProperties:


### PR DESCRIPTION
Fix `KafkaConnectionError`: Unable to bootstrap in stage by always using `SASL_SSL` when Clowder configures SASL auth, and falling back to the system trust store when no custom CA cert is provided. The previous `SASL_PLAINTEXT` fallback (added in #338) sent plaintext to MSK's SSL-only port 9096, which the brokers rejected.

This PR changes:
- `notificator_config.py` — `kafka_security_protocol` now always returns `SASL_SSL` when the broker authtype is SASL, matching the vulnerability-engine pattern. Removed the `broker.cacert conditional` and the `SASL_PLAINTEXT` branch.
- `kafka.py` — `_build_ssl_context` now creates an SSL context whenever the protocol is SASL_SSL. When `kafka_ca_path` is None (no Clowder-provided CA), `create_ssl_context(cafile=None)` loads the system trust store as a fallback.