### PR TITLE
Add proxy when fetching from notification backend

### DIFF
--- a/src/notificator/subscriptions.py
+++ b/src/notificator/subscriptions.py
@@ -49,7 +49,7 @@ async def fetch_subscribed_org_ids(settings: NotificatorSettings, subscription: 
 
     logger.info("Fetching subscribed org IDs", url=url, event_type=subscription.event_type)
 
-    async with httpx.AsyncClient(verify=ctx, timeout=180) as client:
+    async with httpx.AsyncClient(verify=ctx, timeout=180, proxy="http://squid.corp.redhat.com:3128") as client:
         response = await client.get(url, params={"eventTypeNames": subscription.event_type})
         response.raise_for_status()
         data = response.json()

--- a/tests/notificator/test_subscriptions.py
+++ b/tests/notificator/test_subscriptions.py
@@ -156,7 +156,7 @@ class TestFetchSubscribedOrgIds:
 
         ssl_create.assert_called_once()
         ssl_ctx.load_cert_chain.assert_called_once_with(certfile=settings.tls_cert_path, keyfile=settings.tls_key_path)
-        mock_cls.assert_called_once_with(verify=ssl_ctx, timeout=180)
+        mock_cls.assert_called_once_with(verify=ssl_ctx, timeout=180, proxy="http://squid.corp.redhat.com:3128")
 
     async def test_different_subscription_uses_correct_key_and_path(self, mocker, settings):
         other = SubscriptionType("other-app", "some-other-event")


### PR DESCRIPTION
Proxy is needed, without it we are getting 403 Forbidden error when trying to fetch registered org_ids to receive notification in stage.