### PR TITLE
Add subscribed-orgs admin endpoint

### DIFF
--- a/src/roadmap/admin/notificator.py
+++ b/src/roadmap/admin/notificator.py
@@ -10,6 +10,8 @@ from pydantic import field_validator
 
 from notificator.kafka import KafkaBrokersNotConfigured
 from notificator.lifecycle import lifecycle_notification
+from notificator.notificator_config import LIFECYCLE_SUBSCRIPTION
+from notificator.subscriptions import get_org_ids
 
 
 logger = structlog.get_logger(__name__)
@@ -63,6 +65,18 @@ async def _trigger_lifecycle_notification_background(org_ids: list[int] | None =
             org_ids=org_ids,
             total_orgs=len(org_ids or []),
         )
+
+
+@router.get("/notificator/subscribed-orgs", summary="List orgs subscribed to lifecycle notifications")
+async def get_subscribed_orgs():
+    try:
+        org_ids = await get_org_ids(LIFECYCLE_SUBSCRIPTION)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Failed to fetch subscribed org IDs")
+        raise HTTPException(status_code=500, detail="Failed to fetch subscribed org IDs") from exc
+    return {"org_ids": org_ids, "count": len(org_ids)}
 
 
 @router.post("/notificator/custom", summary="Trigger lifecycle notification for one or more orgs")

--- a/tests/admin/test_notificator.py
+++ b/tests/admin/test_notificator.py
@@ -11,11 +11,17 @@ from notificator.kafka import KafkaBrokersNotConfigured
 
 ADMIN_NOTIFICATOR_CUSTOM_URL = "/api/roadmap/admin/notificator/custom"
 ADMIN_NOTIFICATOR_ALL_URL = "/api/roadmap/admin/notificator/all"
+ADMIN_NOTIFICATOR_SUBSCRIBED_ORGS_URL = "/api/roadmap/admin/notificator/subscribed-orgs"
 
 
 @pytest.fixture(autouse=True)
 def _patch_lifecycle_notification(mocker):
     return mocker.patch("roadmap.admin.notificator.lifecycle_notification", new_callable=AsyncMock)
+
+
+@pytest.fixture()
+def _patch_get_org_ids(mocker):
+    return mocker.patch("roadmap.admin.notificator.get_org_ids", new_callable=AsyncMock)
 
 
 class TestCustomEndpointValidation:
@@ -90,3 +96,41 @@ class TestTriggerNotificator:
         # Background wrapper swallows errors and only logs.
         assert response.status_code == 202
         _patch_lifecycle_notification.assert_awaited_once_with(override_org_ids=None)
+
+
+class TestSubscribedOrgs:
+    """Tests for GET /notificator/subscribed-orgs endpoint."""
+
+    def test_returns_subscribed_org_ids(self, client, _patch_get_org_ids):
+        _patch_get_org_ids.return_value = [1, 2, 3]
+
+        response = client.get(ADMIN_NOTIFICATOR_SUBSCRIBED_ORGS_URL)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body == {"org_ids": [1, 2, 3], "count": 3}
+
+    def test_returns_empty_list_when_no_subscriptions(self, client, _patch_get_org_ids):
+        _patch_get_org_ids.return_value = []
+
+        response = client.get(ADMIN_NOTIFICATOR_SUBSCRIBED_ORGS_URL)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body == {"org_ids": [], "count": 0}
+
+    def test_returns_503_when_subscriptions_url_not_configured(self, client, _patch_get_org_ids):
+        _patch_get_org_ids.side_effect = RuntimeError("ROADMAP_SUBSCRIPTIONS_URL is not configured")
+
+        response = client.get(ADMIN_NOTIFICATOR_SUBSCRIBED_ORGS_URL)
+
+        assert response.status_code == 503
+        assert "ROADMAP_SUBSCRIPTIONS_URL is not configured" in response.json()["detail"]
+
+    def test_returns_500_on_unexpected_error(self, client, _patch_get_org_ids):
+        _patch_get_org_ids.side_effect = Exception("connection timeout")
+
+        response = client.get(ADMIN_NOTIFICATOR_SUBSCRIBED_ORGS_URL)
+
+        assert response.status_code == 500
+        assert "Failed to fetch subscribed org IDs" in response.json()["detail"]


### PR DESCRIPTION
Recently we had an issue with the `get_org_ids` not being able to connect in our internal cluster. I'd like to add a admin endpoint which only runs this functions without sending any notification to be able to test it.