### PR TITLE
[RSPEED-3090] Allow stage non internal users to invoke admin endpoints

### DIFF
--- a/deploy/config.yml
+++ b/deploy/config.yml
@@ -98,6 +98,9 @@ objects:
               - name: SENTRY_ENVIRONMENT
                 value: ${ENV_NAME}
 
+              - name: ROADMAP_ENV_NAME
+                value: ${ENV_NAME}
+
             resources:
               limits:
                 cpu: "${CPU_LIMIT_SERVICE}"

--- a/src/roadmap/admin/__init__.py
+++ b/src/roadmap/admin/__init__.py
@@ -7,11 +7,14 @@ from fastapi import Depends
 from fastapi import Header
 from fastapi import HTTPException
 
+from roadmap.config import Settings
+
 from . import notificator
 
 
 async def require_internal_user(
     x_rh_identity: t.Annotated[str | None, Header(include_in_schema=False)] = None,
+    settings: Settings = Depends(Settings.create),
 ) -> None:
     """Reject requests that do not come from a Red Hat internal user.
 
@@ -19,7 +22,12 @@ async def require_internal_user(
     base64-encoded JSON blob.  We check
     ``identity.user.is_internal == True`` to restrict access to Red Hat
     associates only.
+
+    In non-production environments the check is skipped.
     """
+    if settings.env_name != "prod":
+        return
+
     if x_rh_identity is None:
         raise HTTPException(status_code=401, detail="Missing x-rh-identity header")
 

--- a/src/roadmap/config.py
+++ b/src/roadmap/config.py
@@ -31,6 +31,7 @@ class Settings(BaseSettings):
     rbac_hostname: str = ""
     rbac_port: int = 8000
 
+    env_name: str = "stage"
     log_level: str = "info"
     json_logging: bool = False
 

--- a/tests/admin/test_notificator.py
+++ b/tests/admin/test_notificator.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from notificator.kafka import KafkaBrokersNotConfigured
+from roadmap.config import Settings
 
 
 ADMIN_NOTIFICATOR_CUSTOM_URL = "/api/roadmap/admin/notificator/custom"
@@ -24,8 +25,21 @@ def _patch_get_org_ids(mocker):
     return mocker.patch("roadmap.admin.notificator.get_org_ids", new_callable=AsyncMock)
 
 
-class TestAdminAuthGuard:
-    """The is_internal check must block unauthenticated and external callers."""
+@pytest.fixture()
+def _force_prod(monkeypatch):
+    """Set env_name to 'prod' so the auth guard is active."""
+    monkeypatch.setenv("ROADMAP_ENV_NAME", "prod")
+    Settings.create.cache_clear()
+    yield
+    Settings.create.cache_clear()
+
+
+class TestAdminAuthGuardProd:
+    """In prod, the is_internal check must block unauthenticated and external callers."""
+
+    @pytest.fixture(autouse=True)
+    def _prod(self, _force_prod):
+        pass
 
     def test_no_identity_header_returns_401(self, client):
         response = client.post(ADMIN_NOTIFICATOR_CUSTOM_URL, json={"org_ids": 1})
@@ -60,6 +74,24 @@ class TestAdminAuthGuard:
 
     def test_internal_user_passes(self, admin_client, _patch_lifecycle_notification):
         response = admin_client.post(ADMIN_NOTIFICATOR_CUSTOM_URL, json={"org_ids": 1})
+
+        assert response.status_code == 200
+
+
+class TestAdminAuthGuardStage:
+    """In stage (default), the auth guard is bypassed."""
+
+    def test_no_header_allowed_in_stage(self, client, _patch_lifecycle_notification):
+        response = client.post(ADMIN_NOTIFICATOR_CUSTOM_URL, json={"org_ids": 1})
+
+        assert response.status_code == 200
+
+    def test_external_user_allowed_in_stage(self, client, external_headers, _patch_lifecycle_notification):
+        response = client.post(
+            ADMIN_NOTIFICATOR_CUSTOM_URL,
+            json={"org_ids": 1},
+            headers=external_headers,
+        )
 
         assert response.status_code == 200
 


### PR DESCRIPTION
Recently I added a dependency on the admin endpoints so only internal users can invoke them, however the test accounts on stage are not internal so we blocked the testing there. This PR makes the admin endpoint environment aware.