### PR TITLE
[RSPEED-2869, RSPEED-2866] Add roadmap notifications

### DIFF
--- a/src/notificator/__main__.py
+++ b/src/notificator/__main__.py
@@ -5,8 +5,8 @@ import asyncio
 import structlog
 
 from notificator.lifecycle import lifecycle_notification
-from notificator.lifecycle import roadmap_notification
 from notificator.notificator_config import NotificatorSettings
+from notificator.roadmap import roadmap_notification
 from roadmap.custom_logging import setup_logging
 
 

--- a/src/notificator/lifecycle.py
+++ b/src/notificator/lifecycle.py
@@ -49,7 +49,3 @@ async def lifecycle_notification(override_org_ids: list[int] | None = None):
 
     if failed_orgs:
         raise RuntimeError(f"Lifecycle notification failed for {len(failed_orgs)}/{len(org_ids)} orgs: {failed_orgs}")
-
-
-async def roadmap_notification():
-    pass

--- a/src/notificator/notificator.py
+++ b/src/notificator/notificator.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import time
 
+from collections import Counter
+from datetime import date
 from datetime import datetime
+from datetime import timedelta
 from datetime import UTC
 from uuid import uuid4
 
@@ -14,6 +17,7 @@ from roadmap.common import query_host_inventory
 from roadmap.database import get_db
 from roadmap.models import SupportStatus
 from roadmap.models import SystemInfo
+from roadmap.v1 import upcoming
 from roadmap.v1.lifecycle.app_streams import systems_by_app_stream
 from roadmap.v1.lifecycle.rhel import get_relevant_systems
 
@@ -177,6 +181,149 @@ class Notificator:
 
         logger.info("Built lifecycle notification", org_id=self.org_id, event_type="retiring-lifecycle-monthly-report")
         return payload
+
+    async def get_relevant_upcoming(self, hosts) -> Counter[str]:
+        """Get upcoming changes added within the last-month-to-date window.
+
+        Calls the same logic as the ``/relevant/upcoming-changes`` endpoint but
+        further filters to items whose ``dateAdded`` falls between the 1st of
+        the previous month and today (inclusive).
+
+        Returns a Counter keyed by ``UpcomingType`` value (addition, change,
+        deprecation, enhancement).  Merging enhancement into addition is done
+        at payload-build time so the raw counts stay separable.
+        """
+        start_time = time.time()
+        logger.info("Processing upcoming changes", org_id=self.org_id)
+
+        pkgs_by_system = await upcoming.packages_by_system(
+            org_id=str(self.org_id),
+            systems=CachedResult(hosts),  # pyright: ignore [reportArgumentType]
+        )
+
+        upcoming_with_hosts = upcoming.get_upcoming_data_with_hosts(
+            packages_by_system=pkgs_by_system,
+            settings=self.settings,
+        )
+
+        cutoff = _upcoming_cutoff_date()
+        today = date.today()
+        counts: Counter[str] = Counter()
+
+        for item in upcoming_with_hosts:
+            if cutoff <= item.details.dateAdded <= today:
+                logger.info(f"Processing {item}")
+                counts[item.type] += 1
+
+        elapsed = time.time() - start_time
+        logger.info(
+            "Processed upcoming changes",
+            org_id=self.org_id,
+            total_upcoming=len(upcoming_with_hosts),
+            filtered_count=sum(counts.values()),
+            counts=dict(counts),
+            cutoff_date=str(cutoff),
+            duration_seconds=round(elapsed, 2),
+        )
+        return counts
+
+    async def get_roadmap_notification(self) -> dict:
+        """Gather required information for notification and build kafka message for notification backend."""
+        logger.info("Building roadmap notification", org_id=self.org_id)
+
+        hosts = await self.get_hosts()
+        upcoming_counts = await self.get_relevant_upcoming(hosts)
+
+        payload = _build_roadmap_notification_payload(
+            upcoming_counts=upcoming_counts,
+            org_id=str(self.org_id),
+        )
+
+        logger.info("Built roadmap notification", org_id=self.org_id, event_type="roadmap-monthly-report")
+        return payload
+
+
+def _upcoming_cutoff_date() -> date:
+    """Return the first day of the previous month (start of the reporting window).
+
+    The reporting window spans from the 1st of the previous month to today,
+    e.g. if today is May 2 the cutoff is April 1.
+    """
+    first_of_this_month = date.today().replace(day=1)
+    last_of_prev_month = first_of_this_month - timedelta(days=1)
+    return last_of_prev_month.replace(day=1)
+
+
+def _build_roadmap_notification_payload(
+    upcoming_counts: Counter[str],
+    org_id: str,
+    bundle: str = "rhel",
+    application: str = "roadmap",
+    event_type: str = "roadmap-monthly-report",
+) -> dict:
+    """Build kafka message for roadmap notification backend using their specified format.
+
+    ``enhancement`` counts are folded into ``addition`` for the payload.
+
+    Returns::
+
+        {
+            "version": "v1.0.0",
+            "id": "63961201-...",
+            "bundle": "rhel",
+            "application": "roadmap",
+            "event_type": "roadmap-monthly-report",
+            "timestamp": "2026-04-15T15:50:05Z",
+            "org_id": "1234",
+            "context": {
+                "roadmap": {
+                    "report_date": "April 2026"
+                }
+            },
+            "events": [{
+                "metadata": {},
+                "payload": {
+                    "addition": {"count": 4},
+                    "deprecation": {"count": 5},
+                    "change": {"count": 0},
+                }
+            }],
+            "recipients": [],
+        }
+    """
+    now = datetime.now(UTC)
+    timestamp = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    first_of_this_month = now.date().replace(day=1)
+    previous_month = first_of_this_month - timedelta(days=1)
+    report_date = previous_month.strftime("%B %Y")
+
+    payload_counts = {
+        "addition": upcoming_counts["addition"] + upcoming_counts["enhancement"],
+        "deprecation": upcoming_counts["deprecation"],
+        "change": upcoming_counts["change"],
+    }
+
+    return {
+        "version": "v1.0.0",
+        "id": str(uuid4()),
+        "bundle": bundle,
+        "application": application,
+        "event_type": event_type,
+        "timestamp": timestamp,
+        "org_id": org_id,
+        "context": {
+            application: {
+                "report_date": report_date,
+            }
+        },
+        "events": [
+            {
+                "metadata": {},
+                "payload": {type_key: {"count": count} for type_key, count in payload_counts.items()},
+            },
+        ],
+        "recipients": [],
+    }
 
 
 def _build_notification_payload(

--- a/src/notificator/notificator.py
+++ b/src/notificator/notificator.py
@@ -215,7 +215,14 @@ class Notificator:
         counts: Counter[str] = Counter()
 
         for item in upcoming_with_hosts:
-            if cutoff <= item.details.dateAdded <= today:
+            if item.details.deployedDate is None:
+                # Item was not released yet, let's use today's date for testing
+                # Shouldn't happen in production, meant mainly for staging
+                logger.info(
+                    f"{item.name} was not yet deployed, added to roadmap on {item.details.dateAdded}. Using today's date."
+                )
+                item.details.deployedDate = date.today()
+            if cutoff <= item.details.deployedDate <= today:
                 counts[item.type] += 1
 
         elapsed = time.time() - start_time

--- a/src/notificator/notificator.py
+++ b/src/notificator/notificator.py
@@ -210,8 +210,8 @@ class Notificator:
             settings=self.settings,
         )
 
-        cutoff = _upcoming_cutoff_date()
-        today = date.today()
+        today = datetime.now(UTC).date()
+        cutoff = _upcoming_cutoff_date(today)
         counts: Counter[str] = Counter()
 
         for item in upcoming_with_hosts:
@@ -221,7 +221,7 @@ class Notificator:
                 logger.info(
                     f"{item.name} was not yet deployed, added to roadmap on {item.details.dateAdded}. Using today's date."
                 )
-                item.details.deployedDate = date.today()
+                item.details.deployedDate = today
             if cutoff <= item.details.deployedDate <= today:
                 counts[item.type] += 1
 
@@ -251,13 +251,13 @@ class Notificator:
         return payload
 
 
-def _upcoming_cutoff_date() -> date:
+def _upcoming_cutoff_date(reference_date: date) -> date:
     """Return the first day of the previous month (start of the reporting window).
 
     The reporting window spans from the 1st of the previous month to today,
     e.g. if today is May 2 the cutoff is April 1.
     """
-    first_of_this_month = date.today().replace(day=1)
+    first_of_this_month = reference_date.replace(day=1)
     last_of_prev_month = first_of_this_month - timedelta(days=1)
     return last_of_prev_month.replace(day=1)
 

--- a/src/notificator/notificator.py
+++ b/src/notificator/notificator.py
@@ -171,7 +171,7 @@ class Notificator:
         rhel_grouped = await self.get_relevant_rhel(hosts)
         appstream_grouped = await self.get_relevant_appstreams(hosts)
 
-        payload = _build_notification_payload(
+        payload = _build_lifecycle_notification_payload(
             rhel_grouped=rhel_grouped,
             appstream_grouped=appstream_grouped,
             org_id=str(self.org_id),
@@ -192,6 +192,10 @@ class Notificator:
         Returns a Counter keyed by ``UpcomingType`` value (addition, change,
         deprecation, enhancement).  Merging enhancement into addition is done
         at payload-build time so the raw counts stay separable.
+
+        Example::
+
+            Counter({"addition": 5, "deprecation": 2, "change": 1, "enhancement": 3})
         """
         start_time = time.time()
         logger.info("Processing upcoming changes", org_id=self.org_id)
@@ -212,15 +216,12 @@ class Notificator:
 
         for item in upcoming_with_hosts:
             if cutoff <= item.details.dateAdded <= today:
-                logger.info(f"Processing {item}")
                 counts[item.type] += 1
 
         elapsed = time.time() - start_time
         logger.info(
             "Processed upcoming changes",
             org_id=self.org_id,
-            total_upcoming=len(upcoming_with_hosts),
-            filtered_count=sum(counts.values()),
             counts=dict(counts),
             cutoff_date=str(cutoff),
             duration_seconds=round(elapsed, 2),
@@ -326,7 +327,7 @@ def _build_roadmap_notification_payload(
     }
 
 
-def _build_notification_payload(
+def _build_lifecycle_notification_payload(
     rhel_grouped: dict[str, dict[str, int]],
     appstream_grouped: dict[str, dict[str, dict[str, int]]],
     org_id: str,

--- a/src/notificator/roadmap.py
+++ b/src/notificator/roadmap.py
@@ -1,0 +1,51 @@
+import time
+
+import structlog
+
+from notificator.kafka import kafka_producer
+from notificator.notificator import Notificator
+from notificator.notificator_config import ROADMAP_SUBSCRIPTION
+from notificator.subscriptions import get_org_ids
+
+
+logger = structlog.get_logger(__name__)
+
+
+async def roadmap_notification(override_org_ids: list[int] | None = None):
+    logger.info("Started roadmap notification")
+    roadmap_notification_start_time = time.time()
+    org_ids = override_org_ids if override_org_ids is not None else await get_org_ids(ROADMAP_SUBSCRIPTION)
+    if not org_ids:
+        logger.warning("No subscribed org IDs found, skipping roadmap notification")
+        return
+
+    failed_orgs = []
+
+    async with kafka_producer() as producer:
+        for org_id in org_ids:
+            start_time = time.time()
+            logger.info("Processing roadmap notification", org_id=org_id)
+            try:
+                n = Notificator(org_id=org_id)
+                payload = await n.get_roadmap_notification()
+                logger.debug("Payload generated", org_id=org_id, payload=payload)
+                await producer.send_notification(payload)
+                elapsed = time.time() - start_time
+                logger.info("Roadmap notification completed", org_id=org_id, duration_seconds=round(elapsed, 2))
+            # Wide exception, we don't want one failed ORG_ID causing failure of the whole script.
+            except Exception:
+                elapsed = time.time() - start_time
+                logger.exception(
+                    "Failed to process roadmap notification", org_id=org_id, duration_seconds=round(elapsed, 2)
+                )
+                failed_orgs.append(org_id)
+
+    roadmap_notification_elapsed = time.time() - roadmap_notification_start_time
+    logger.info(
+        "Finished roadmap notification",
+        duration_seconds=roadmap_notification_elapsed,
+        processed_org_ids=len(org_ids),
+    )
+
+    if failed_orgs:
+        raise RuntimeError(f"Roadmap notification failed for {len(failed_orgs)}/{len(org_ids)} orgs: {failed_orgs}")

--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -6,6 +6,7 @@ import typing as t
 import urllib.parse
 import urllib.request
 
+from collections.abc import AsyncGenerator
 from datetime import date
 from urllib.error import HTTPError
 from uuid import UUID
@@ -19,6 +20,7 @@ from fastapi.openapi.utils import get_openapi
 from sqlalchemy import RowMapping
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import text
 
@@ -170,7 +172,7 @@ async def query_host_inventory(
     host_groups: t.Annotated[set[str | None], Depends(get_allowed_host_groups)],
     major: MajorVersion | None = None,
     minor: MinorVersion | None = None,
-):
+) -> AsyncGenerator[AsyncResult[t.Any]]:
     """
     Query the Hosts database for system information on this org's hosts.
 

--- a/tests/notificator/test_notificator.py
+++ b/tests/notificator/test_notificator.py
@@ -1,5 +1,7 @@
 from collections import Counter
 from datetime import date
+from datetime import datetime
+from datetime import timezone
 from unittest.mock import AsyncMock
 
 import pytest
@@ -356,11 +358,8 @@ class TestUpcomingCutoffDate:
             pytest.param(date(2026, 3, 31), date(2026, 2, 1), id="last_day_of_month"),
         ),
     )
-    def test_cutoff_date(self, mocker, today_date, expected_cutoff):
-        mock_date = mocker.patch("notificator.notificator.date", wraps=date)
-        mock_date.today.return_value = today_date
-
-        result = _upcoming_cutoff_date()
+    def test_cutoff_date(self, today_date, expected_cutoff):
+        result = _upcoming_cutoff_date(today_date)
 
         assert result == expected_cutoff
 
@@ -420,11 +419,12 @@ class TestGetRelevantUpcoming:
 
     @pytest.fixture(autouse=True)
     def _freeze_today(self, mocker):
-        """Pin date.today() to May 15 2026 so the window is April 1 - May 15."""
+        """Pin datetime.now(UTC) to May 15 2026 so the window is April 1 - May 15."""
         self.today = date(2026, 5, 15)
         self.cutoff = date(2026, 4, 1)
-        mock_date = mocker.patch("notificator.notificator.date", wraps=date)
-        mock_date.today.return_value = self.today
+        frozen = datetime(2026, 5, 15, 12, 0, 0, tzinfo=timezone.utc)
+        mock_dt = mocker.patch("notificator.notificator.datetime", wraps=datetime)
+        mock_dt.now.return_value = frozen
 
     @pytest.fixture(autouse=True)
     def _mock_upcoming_deps(self, mocker):

--- a/tests/notificator/test_notificator.py
+++ b/tests/notificator/test_notificator.py
@@ -1,9 +1,12 @@
+from collections import Counter
 from datetime import date
 from unittest.mock import AsyncMock
 
 import pytest
 
-from notificator.notificator import _build_notification_payload
+from notificator.notificator import _build_lifecycle_notification_payload
+from notificator.notificator import _build_roadmap_notification_payload
+from notificator.notificator import _upcoming_cutoff_date
 from roadmap.models import Meta
 from roadmap.models import SupportStatus
 from roadmap.v1.lifecycle.rhel import RelevantSystemsResponse
@@ -15,6 +18,7 @@ from .utils import FIXED_UUID
 from .utils import make_appstream_key
 from .utils import make_system
 from .utils import make_system_info
+from .utils import make_upcoming_output
 from .utils import ORG_ID
 
 
@@ -270,7 +274,7 @@ class TestNotificator:
         assert len(payload["events"]) == 1
         assert payload["events"][0]["payload"] == {**rhel, **appstreams}
 
-    def test_build_notification_payload(self, mock_deterministic):
+    def test_build_lifecycle_notification_payload(self, mock_deterministic):
         """All fields of the Kafka notification payload match the expected schema."""
         rhel = {
             "rhel_retired": {"rhel_versions_count": 2, "systems_count": 10},
@@ -281,7 +285,7 @@ class TestNotificator:
             "appstream_near_retirement": {"rhel9": {"count": 1, "systems_count": 2}},
         }
 
-        result = _build_notification_payload(
+        result = _build_lifecycle_notification_payload(
             rhel_grouped=rhel,
             appstream_grouped=appstream,
             org_id=str(ORG_ID),
@@ -301,9 +305,9 @@ class TestNotificator:
         assert len(result["events"]) == 1
         assert result["events"][0]["payload"] == {**rhel, **appstream}
 
-    def test_build_notification_payload_empty_data(self, mock_deterministic):
+    def test_build_lifecycle_notification_payload_empty_data(self, mock_deterministic):
         """With zeroed/empty inputs the payload still has the correct structure."""
-        result = _build_notification_payload(
+        result = _build_lifecycle_notification_payload(
             rhel_grouped=EMPTY_RHEL_SECTIONS,
             appstream_grouped=EMPTY_APPSTREAM_SECTIONS,
             org_id=str(ORG_ID),
@@ -315,3 +319,201 @@ class TestNotificator:
         assert result["events"][0]["payload"] == {**EMPTY_RHEL_SECTIONS, **EMPTY_APPSTREAM_SECTIONS}
         assert result["events"][0]["metadata"] == {}
         assert result["context"] == {"lifecycle": {"report_date": "March 2026"}}
+
+    async def test_get_roadmap_notification(self, notificator, mocker, mock_deterministic):
+        """Orchestration: hosts are fetched once and passed to get_relevant_upcoming."""
+        sentinel_hosts = [{"id": "sentinel"}]
+        upcoming_counts = Counter({"addition": 3, "deprecation": 1, "change": 0})
+        mock_hosts = mocker.patch.object(notificator, "get_hosts", new_callable=AsyncMock, return_value=sentinel_hosts)
+        mock_upcoming = mocker.patch.object(
+            notificator, "get_relevant_upcoming", new_callable=AsyncMock, return_value=upcoming_counts
+        )
+
+        payload = await notificator.get_roadmap_notification()
+
+        mock_hosts.assert_awaited_once()
+        mock_upcoming.assert_awaited_once_with(sentinel_hosts)
+        assert payload["event_type"] == "roadmap-monthly-report"
+        assert payload["org_id"] == str(ORG_ID)
+        assert payload["application"] == "roadmap"
+        assert len(payload["events"]) == 1
+        assert payload["events"][0]["payload"] == {
+            "addition": {"count": 3},
+            "deprecation": {"count": 1},
+            "change": {"count": 0},
+        }
+
+
+class TestUpcomingCutoffDate:
+    """_upcoming_cutoff_date: returns first of previous month for the reporting window."""
+
+    @pytest.mark.parametrize(
+        ("today_date", "expected_cutoff"),
+        (
+            pytest.param(date(2026, 5, 15), date(2026, 4, 1), id="mid_month"),
+            pytest.param(date(2026, 5, 1), date(2026, 4, 1), id="first_of_month"),
+            pytest.param(date(2026, 1, 10), date(2025, 12, 1), id="january_wraps_year"),
+            pytest.param(date(2026, 3, 31), date(2026, 2, 1), id="last_day_of_month"),
+        ),
+    )
+    def test_cutoff_date(self, mocker, today_date, expected_cutoff):
+        mock_date = mocker.patch("notificator.notificator.date", wraps=date)
+        mock_date.today.return_value = today_date
+
+        result = _upcoming_cutoff_date()
+
+        assert result == expected_cutoff
+
+
+class TestBuildRoadmapNotificationPayload:
+    """_build_roadmap_notification_payload: Kafka message structure for roadmap notifications."""
+
+    def test_happy_path(self, mock_deterministic):
+        """All fields match the expected schema with real counts."""
+        counts = Counter({"addition": 2, "deprecation": 3, "change": 1})
+
+        result = _build_roadmap_notification_payload(upcoming_counts=counts, org_id=str(ORG_ID))
+
+        assert result["version"] == "v1.0.0"
+        assert result["id"] == str(FIXED_UUID)
+        assert result["bundle"] == "rhel"
+        assert result["application"] == "roadmap"
+        assert result["event_type"] == "roadmap-monthly-report"
+        assert result["timestamp"] == FIXED_TIMESTAMP
+        assert result["org_id"] == str(ORG_ID)
+        assert result["recipients"] == []
+        assert len(result["events"]) == 1
+        assert result["events"][0]["metadata"] == {}
+        assert result["events"][0]["payload"] == {
+            "addition": {"count": 2},
+            "deprecation": {"count": 3},
+            "change": {"count": 1},
+        }
+
+    def test_empty_counter(self, mock_deterministic):
+        """Empty Counter produces zero counts for all three types."""
+        result = _build_roadmap_notification_payload(upcoming_counts=Counter(), org_id=str(ORG_ID))
+
+        assert result["events"][0]["payload"] == {
+            "addition": {"count": 0},
+            "deprecation": {"count": 0},
+            "change": {"count": 0},
+        }
+
+    def test_enhancement_folded_into_addition(self, mock_deterministic):
+        """Enhancement counts are merged into addition in the payload."""
+        counts = Counter({"addition": 2, "enhancement": 3})
+
+        result = _build_roadmap_notification_payload(upcoming_counts=counts, org_id=str(ORG_ID))
+
+        assert result["events"][0]["payload"]["addition"] == {"count": 5}
+
+    def test_report_date_is_previous_month(self, mock_deterministic):
+        """FIXED_DATETIME is March 15 2026, so report_date should be February 2026."""
+        result = _build_roadmap_notification_payload(upcoming_counts=Counter(), org_id=str(ORG_ID))
+
+        assert result["context"] == {"roadmap": {"report_date": "February 2026"}}
+
+
+class TestGetRelevantUpcoming:
+    """get_relevant_upcoming: date filtering and type counting of upcoming changes."""
+
+    @pytest.fixture(autouse=True)
+    def _freeze_today(self, mocker):
+        """Pin date.today() to May 15 2026 so the window is April 1 - May 15."""
+        self.today = date(2026, 5, 15)
+        self.cutoff = date(2026, 4, 1)
+        mock_date = mocker.patch("notificator.notificator.date", wraps=date)
+        mock_date.today.return_value = self.today
+
+    @pytest.fixture(autouse=True)
+    def _mock_upcoming_deps(self, mocker):
+        """Mock the data-fetching layer; tests control results via self.mock_get_upcoming."""
+        self.mock_packages = mocker.patch(
+            "notificator.notificator.upcoming.packages_by_system",
+            new_callable=AsyncMock,
+            return_value={},
+        )
+        self.mock_get_upcoming = mocker.patch(
+            "notificator.notificator.upcoming.get_upcoming_data_with_hosts",
+            return_value=[],
+        )
+
+    async def test_items_within_window_counted(self, notificator):
+        """Items with dateAdded inside the window are counted by type."""
+        self.mock_get_upcoming.return_value = [
+            make_upcoming_output("addition", date(2026, 4, 10)),
+            make_upcoming_output("addition", date(2026, 5, 1)),
+            make_upcoming_output("deprecation", date(2026, 4, 20)),
+        ]
+
+        result = await notificator.get_relevant_upcoming(hosts=[])
+
+        assert result == Counter({"addition": 2, "deprecation": 1})
+
+    async def test_items_outside_window_excluded(self, notificator):
+        """Items before cutoff or after today produce empty Counter."""
+        self.mock_get_upcoming.return_value = [
+            make_upcoming_output("addition", date(2026, 3, 31)),
+            make_upcoming_output("deprecation", date(2026, 5, 16)),
+        ]
+
+        result = await notificator.get_relevant_upcoming(hosts=[])
+
+        assert sum(result.values()) == 0
+
+    async def test_boundary_dates_inclusive(self, notificator):
+        """Items on the exact cutoff date and exact today date are both included."""
+        self.mock_get_upcoming.return_value = [
+            make_upcoming_output("addition", self.cutoff),
+            make_upcoming_output("change", self.today),
+        ]
+
+        result = await notificator.get_relevant_upcoming(hosts=[])
+
+        assert result == Counter({"addition": 1, "change": 1})
+
+    async def test_enhancement_tracked_separately(self, notificator):
+        """Enhancement is counted under its own key, not merged into addition.
+
+        This scenario is not needed in actual implementation and those could be merged.
+        But in case we later decide to split those, we have an easy option.
+        """
+        self.mock_get_upcoming.return_value = [
+            make_upcoming_output("addition", date(2026, 4, 5)),
+            make_upcoming_output("enhancement", date(2026, 4, 5)),
+        ]
+
+        result = await notificator.get_relevant_upcoming(hosts=[])
+
+        assert result["addition"] == 1
+        assert result["enhancement"] == 1
+
+    async def test_empty_upcoming(self, notificator):
+        """No upcoming items yields empty Counter."""
+        result = await notificator.get_relevant_upcoming(hosts=[])
+
+        assert sum(result.values()) == 0
+
+    async def test_mixed_in_and_out_of_window(self, notificator):
+        """Only items within the window are counted."""
+        self.mock_get_upcoming.return_value = [
+            make_upcoming_output("addition", date(2026, 4, 10)),
+            make_upcoming_output("deprecation", date(2026, 3, 15)),
+            make_upcoming_output("change", date(2026, 5, 10)),
+        ]
+
+        result = await notificator.get_relevant_upcoming(hosts=[])
+
+        assert result == Counter({"addition": 1, "change": 1})
+
+    async def test_same_name_different_types_counted_independently(self, notificator):
+        """Two items sharing a name but differing in type are counted separately."""
+        self.mock_get_upcoming.return_value = [
+            make_upcoming_output("addition", date(2026, 4, 10), name="shared-pkg"),
+            make_upcoming_output("change", date(2026, 4, 10), name="shared-pkg"),
+        ]
+
+        result = await notificator.get_relevant_upcoming(hosts=[])
+
+        assert result == Counter({"addition": 1, "change": 1})

--- a/tests/notificator/test_roadmap.py
+++ b/tests/notificator/test_roadmap.py
@@ -1,4 +1,4 @@
-"""Tests for notificator.__main__ — lifecycle notification orchestration and entry point."""
+"""Tests for notificator.roadmap — roadmap notification orchestration."""
 
 from __future__ import annotations
 
@@ -6,42 +6,41 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from notificator.__main__ import lifecycle_notification
-from notificator.__main__ import main
+from notificator.roadmap import roadmap_notification
 
 from .utils import fake_kafka_ctx
 from .utils import FakeNotificationProducer
 
 
-class TestLifecycleNotification:
-    """lifecycle_notification: org iteration, payload dispatch, failure collection."""
+class TestRoadmapNotification:
+    """roadmap_notification: org iteration, payload dispatch, failure collection."""
 
     @pytest.fixture(autouse=True)
     def _setup(self, mocker):
         self.producer = FakeNotificationProducer()
         mocker.patch(
-            "notificator.lifecycle.kafka_producer",
+            "notificator.roadmap.kafka_producer",
             side_effect=lambda: fake_kafka_ctx(self.producer),
         )
 
     def _patch_notificator(self, mocker, org_ids, *, return_value=None, side_effect=None):
-        """Patch get_org_ids and Notificator in one call; returns the class mock."""
-        mocker.patch("notificator.lifecycle.get_org_ids", return_value=org_ids)
-        mock_cls = mocker.patch("notificator.lifecycle.Notificator")
+        """Patch get_org_ids and Notificator in one call; returns (cls_mock, get_org_ids_mock)."""
+        get_mock = mocker.patch("notificator.roadmap.get_org_ids", new_callable=AsyncMock, return_value=org_ids)
+        mock_cls = mocker.patch("notificator.roadmap.Notificator")
         instance = AsyncMock()
         if side_effect is not None:
-            instance.get_lifecycle_notification.side_effect = side_effect
+            instance.get_roadmap_notification.side_effect = side_effect
         elif return_value is not None:
-            instance.get_lifecycle_notification.return_value = return_value
+            instance.get_roadmap_notification.return_value = return_value
         mock_cls.return_value = instance
-        return mock_cls
+        return mock_cls, get_mock
 
     async def test_single_org_sends_payload(self, mocker):
         """Happy path: one org produces a payload that reaches the producer."""
         payload = {"org_id": "42", "events": []}
         self._patch_notificator(mocker, [42], return_value=payload)
 
-        await lifecycle_notification()
+        await roadmap_notification()
 
         assert self.producer.sent == [payload]
 
@@ -49,7 +48,7 @@ class TestLifecycleNotification:
         """All orgs succeed — no error raised, each payload sent."""
         self._patch_notificator(mocker, [1, 2, 3], return_value={"ok": True})
 
-        await lifecycle_notification()
+        await roadmap_notification()
 
         assert len(self.producer.sent) == 3
 
@@ -58,7 +57,7 @@ class TestLifecycleNotification:
         self._patch_notificator(mocker, [99], side_effect=ValueError("boom"))
 
         with pytest.raises(RuntimeError, match="1/1 orgs"):
-            await lifecycle_notification()
+            await roadmap_notification()
 
     async def test_partial_failure_continues_remaining_orgs(self, mocker):
         """One org fails mid-batch; the rest still send their payloads."""
@@ -69,7 +68,7 @@ class TestLifecycleNotification:
         )
 
         with pytest.raises(RuntimeError, match=r"1/3 orgs: \[2\]"):
-            await lifecycle_notification()
+            await roadmap_notification()
 
         assert len(self.producer.sent) == 2
 
@@ -78,57 +77,24 @@ class TestLifecycleNotification:
         self._patch_notificator(mocker, [10, 20], side_effect=ValueError("fail"))
 
         with pytest.raises(RuntimeError, match=r"2/2 orgs: \[10, 20\]"):
-            await lifecycle_notification()
+            await roadmap_notification()
 
         assert len(self.producer.sent) == 0
 
-    async def test_notificator_receives_org_id(self, mocker):
-        """Each Notificator is instantiated with the correct org_id."""
-        mock_cls = self._patch_notificator(mocker, [777], return_value={})
-
-        await lifecycle_notification()
-
-        mock_cls.assert_called_once_with(org_id=777)
-
     async def test_no_subscribed_orgs_skips_processing(self, mocker):
         """When get_org_ids returns no orgs, skip without instantiating Notificator."""
-        mock_cls = self._patch_notificator(mocker, [], return_value={})
+        mock_cls, _ = self._patch_notificator(mocker, [], return_value={})
 
-        await lifecycle_notification()
+        await roadmap_notification()
 
         mock_cls.assert_not_called()
         assert len(self.producer.sent) == 0
 
     async def test_explicit_org_ids_bypass_get_org_ids(self, mocker):
         """Passing org_ids skips get_org_ids entirely."""
-        get_mock = mocker.patch("notificator.lifecycle.get_org_ids")
-        mock_cls = mocker.patch("notificator.lifecycle.Notificator")
-        instance = AsyncMock()
-        instance.get_lifecycle_notification.return_value = {"ok": True}
-        mock_cls.return_value = instance
+        _, get_mock = self._patch_notificator(mocker, [], return_value={"ok": True})
 
-        await lifecycle_notification(override_org_ids=[42, 99])
+        await roadmap_notification(override_org_ids=[42, 99])
 
         get_mock.assert_not_called()
         assert len(self.producer.sent) == 2
-
-
-class TestMain:
-    """main(): orchestrates both notification types in order."""
-
-    async def test_calls_lifecycle_then_roadmap(self, mocker):
-        """main() invokes lifecycle and then roadmap notification sequentially."""
-        call_order = []
-
-        async def fake_lifecycle():
-            call_order.append("lifecycle")
-
-        async def fake_roadmap():
-            call_order.append("roadmap")
-
-        mocker.patch("notificator.__main__.lifecycle_notification", side_effect=fake_lifecycle)
-        mocker.patch("notificator.__main__.roadmap_notification", side_effect=fake_roadmap)
-
-        await main()
-
-        assert call_order == ["lifecycle", "roadmap"]

--- a/tests/notificator/utils.py
+++ b/tests/notificator/utils.py
@@ -119,15 +119,16 @@ def make_system(name, status, count, major, minor=None):
     )
 
 
-def make_upcoming_output(upcoming_type, date_added, name="test-item"):
-    """Build an UpcomingOutput with a given type and dateAdded, bypassing validators."""
+def make_upcoming_output(upcoming_type, deployed_date, name="test-item"):
+    """Build an UpcomingOutput with a given type and deployedDate, bypassing validators."""
     details = UpcomingOutputDetails.model_construct(
         architecture=None,
         detailFormat=0,
         summary="Test summary",
         trainingTicket="",
-        dateAdded=date_added,
-        lastModified=date_added,
+        dateAdded=deployed_date,
+        lastModified=deployed_date,
+        deployedDate=deployed_date,
         potentiallyAffectedSystemsCount=0,
         potentiallyAffectedSystemsDetail=set(),
         potentiallyAffectedSystems=set(),
@@ -137,6 +138,6 @@ def make_upcoming_output(upcoming_type, date_added, name="test-item"):
         type=upcoming_type,
         packages={"test-package"},
         release="9.0",
-        date=date_added,
+        date=deployed_date,
         details=details,
     )

--- a/tests/notificator/utils.py
+++ b/tests/notificator/utils.py
@@ -1,5 +1,6 @@
 """Shared constants and factory functions for notificator tests."""
 
+from contextlib import asynccontextmanager
 from datetime import datetime
 from datetime import UTC
 from uuid import UUID
@@ -11,6 +12,8 @@ from roadmap.models import LifecycleType
 from roadmap.models import System
 from roadmap.models import SystemInfo
 from roadmap.v1.lifecycle.app_streams import AppStreamKey
+from roadmap.v1.upcoming import UpcomingOutput
+from roadmap.v1.upcoming import UpcomingOutputDetails
 
 
 FIXED_UUID = UUID("12345678-1234-5678-1234-567812345678")
@@ -52,6 +55,21 @@ def make_appstream_key(name, display_name, status, os_major):
         rolling=False,
     )
     return AppStreamKey.model_construct(name=name, app_stream_entity=entity)
+
+
+class FakeNotificationProducer:
+    """In-memory KafkaProducer stand-in that records sent payloads without I/O."""
+
+    def __init__(self):
+        self.sent: list[dict] = []
+
+    async def send_notification(self, payload: dict):
+        self.sent.append(payload)
+
+
+@asynccontextmanager
+async def fake_kafka_ctx(producer):
+    yield producer
 
 
 class FakeKafkaProducer:
@@ -98,4 +116,27 @@ def make_system(name, status, count, major, minor=None):
         related=False,
         systems_detail=set(),
         systems=set(),
+    )
+
+
+def make_upcoming_output(upcoming_type, date_added, name="test-item"):
+    """Build an UpcomingOutput with a given type and dateAdded, bypassing validators."""
+    details = UpcomingOutputDetails.model_construct(
+        architecture=None,
+        detailFormat=0,
+        summary="Test summary",
+        trainingTicket="",
+        dateAdded=date_added,
+        lastModified=date_added,
+        potentiallyAffectedSystemsCount=0,
+        potentiallyAffectedSystemsDetail=set(),
+        potentiallyAffectedSystems=set(),
+    )
+    return UpcomingOutput.model_construct(
+        name=name,
+        type=upcoming_type,
+        packages={"test-package"},
+        release="9.0",
+        date=date_added,
+        details=details,
     )


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RSPEED-2866
https://redhat.atlassian.net/browse/RSPEED-2869

Roadmap notifications generate following payload
```
{"version": "v1.0.0", "id": "44109675-53af-40de-85cc-64d09ed8bf0b", "bundle": "rhel", "application": "roadmap", 
"event_type": "roadmap-monthly-report", "timestamp": "2026-06-11T09:49:47Z", "org_id": "1234", "context": 
{"roadmap": {"report_date": "May 2026"}}, "events": [{"metadata": {}, "payload": {"addition": {"count": 2}, 
"deprecation": {"count": 1}, "change": {"count": 1}}}], "recipients": []}
```
Which is then used for generating email (missing colors, weird screenshot, but they were rendered):
<img width="711" height="965" alt="image" src="https://github.com/user-attachments/assets/a3e01d0d-a1af-44c4-b0c4-d23e553ed8e5" />

