### PR TITLE
Sort image tags based on version number and creation time

### DIFF
--- a/scripts/update-konflux-refs.py
+++ b/scripts/update-konflux-refs.py
@@ -118,7 +118,7 @@ def image_tag_sort(value):
         version.append(value.get("start_ts", 0))
         return tuple(version)
     except ValueError:
-        return (value.get("start_ts", 0),)
+        return (0, 0, value.get("start_ts", 0))
 
 
 def filter_tags(

--- a/scripts/update-konflux-refs.py
+++ b/scripts/update-konflux-refs.py
@@ -11,7 +11,6 @@ from concurrent.futures import as_completed
 from concurrent.futures import ThreadPoolExecutor
 from enum import StrEnum
 from itertools import islice
-from operator import itemgetter
 from pathlib import Path
 
 
@@ -104,19 +103,33 @@ def parse_args():
     return parser.parse_args()
 
 
+def image_tag_sort(value):
+    """Sort based on the version number in the tag and the creation date."""
+
+    name = value.get("name", "").replace("-", ".")
+    name_parts = name.split(".")
+    if len(name_parts[-1]) > 16:
+        # This ends in a commit hash, not a number. Drop the hash.
+        # 0.6-622d10efb15c602b5e47d8fd98e374bb2c45c149
+        name_parts = name_parts[:-1]
+
+    try:
+        version = [int(n) for n in name_parts]
+        version.append(value.get("start_ts", 0))
+        return tuple(version)
+    except ValueError:
+        return (value.get("start_ts", 0),)
+
+
 def filter_tags(
     tags: list[dict[str, t.Any]],
-    key: list[str] | None = None,
     reverse: bool = True,
     max_tag_length: int = 128,
 ) -> list[dict[str, t.Any]]:
-    # operator.itemgetter will return a tuple of items if passed a list of items to get.
-    # This means the value used to sort will look like ('0.7', 1765550189).
-    key = key or ["name", "start_ts"]
     exclude = {"unknown"}
     return sorted(
-        (item for item in tags if len(item["name"]) < max_tag_length and item["name"] not in exclude),
-        key=itemgetter(*key),
+        (item for item in tags if len(item["name"]) <= max_tag_length and item["name"] not in exclude),
+        key=image_tag_sort,
         reverse=reverse,
     )
 


### PR DESCRIPTION
Convert the version parts to int for the purpose of sorting. This allows versions such as 0.9 and 0.10 to sort correctly.

Change the comparison for max_tag_length so that it includes tag values of the specified length.

This allows images with versions such as `0.10` to be included and selected correctly.
```
> ./scripts/update-konflux-refs.py -i quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta
quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:
    quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.10@sha256:85102e448619f65a1fb7d4512660f8ec05677f99b724f1f838e1964545d7c857  Tue, 02 Jun 2026 14:11:57 -0000
    quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9@sha256:e6273011f68af3881b3c9e1b06d50a7177b221b1d56f7432755b1b606a5557bc   Tue, 02 Jun 2026 14:12:04 -0000
    quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9@sha256:75ecb662f343f6f34e553c5b37734d28d9b53ce218c2321a19b96c39bf769357   Mon, 25 May 2026 12:14:03 -0000
    quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.8@sha256:40cfd115345e01830c59e0c4f1fab15120e6cb1f78ff0082f328108b9a3a2072   Wed, 22 Apr 2026 18:46:10 -0000
    quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.7@sha256:cde309fc09b68c39ca283c4b121ddf99d900e3ff2cf3d5e7951cb707eeeddfae   Thu, 29 Jan 2026 11:27:53 -0000
    quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.6@sha256:0be0a30dcee3564f1896c7eeb9b6584e4313380c2d1f64fa6886bfe578842722   Mon, 26 Jan 2026 17:51:32 -0000
```