### PR TITLE
Add parameter to trigger repo mirror updates by name

### DIFF
--- a/scripts/trigger-mirror.py
+++ b/scripts/trigger-mirror.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import sys
+import urllib.parse
 import urllib.request
 
 from urllib.error import HTTPError
@@ -14,8 +15,8 @@ if not token:
     sys.exit("Missing GITLAB_TOKEN")
 
 
-def gitlab_mirror_api(project_id: str, method: str = "GET"):
-    url = f"https://gitlab.cee.redhat.com/api/v4/projects/{project_id}/mirror/pull"
+def gitlab_api(path: str, method: str = "GET"):
+    url = f"https://gitlab.cee.redhat.com/api/v4/{path}"
     headers = {
         "PRIVATE-TOKEN": token,
     }
@@ -29,18 +30,34 @@ def gitlab_mirror_api(project_id: str, method: str = "GET"):
         with urllib.request.urlopen(req) as response:
             data = json.load(response)
     except HTTPError as err:
-        sys.exit(err.msg)
+        sys.exit(f"{err.code} {err.reason}: {url}")
 
     return data
 
 
+def resolve_project_id(name: str) -> int:
+    encoded_path = urllib.parse.quote(name, safe="")
+
+    project = gitlab_api(f"projects/{encoded_path}")
+
+    return project["id"]
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--project-id", "-p", type=str, default="116489")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--project-id", "-p", type=int, default=116489)
+    group.add_argument("--name", "-n", type=str)
     args = parser.parse_args()
 
-    last_mirror = gitlab_mirror_api(project_id=args.project_id)
+    project_id = args.project_id
+    if args.name:
+        project_id = resolve_project_id(args.name)
+        print(f"Resolved '{args.name}' to ID {project_id}.")
+
+    mirror_path = f"projects/{project_id}/mirror/pull"
+    last_mirror = gitlab_api(mirror_path)
     print(f"Last mirror update {last_mirror['last_successful_update_at']}")
 
     print("Triggering an update...")
-    gitlab_mirror_api(args.project_id, "POST")
+    gitlab_api(mirror_path, "POST")


### PR DESCRIPTION
Instead of requiring the project ID, it’s now possible to pass in the repo name to trigger a mirror update.

```
> scripts/trigger-mirror.py -n rhel-lightspeed/roadmap/backend
Resolved 'rhel-lightspeed/roadmap/backend' to ID 116489.
Last mirror update 2026-06-10T18:16:02.169Z
Triggering an update...
```