### PR TITLE
[RSPEED-3175] Check only enabled modules on app_streams_from_modules

### DIFF
--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -453,9 +453,11 @@ def app_streams_from_modules(  # noqa: C901
         # a module will be incorrectly included in the results.
         cache_key = (module_name, os_major, stream)
 
-        # Check if module is enabled but not installed - needs package verification
-        if ModuleStatus.enabled in module_status and ModuleStatus.installed not in module_status:
-            # Module is enabled but not marked as installed by DNF
+        # Verify enabled modules via actual package installation.
+        # DNF's "installed" flag can be stale (e.g. after `dnf remove <pkg>`
+        # without `dnf module remove`), so we verify all enabled modules.
+        # FIXME: A disabled module but still installed is not detected.
+        if ModuleStatus.enabled in module_status:
             # Check if we have package mapping data for this module
             expected_packages = MODULE_PACKAGES.get(cache_key)
 
@@ -468,7 +470,7 @@ def app_streams_from_modules(  # noqa: C901
                     # Store in pending_verification dict (not in cache)
                     pending_verification[cache_key] = (app_stream_key, expected_packages)
                     logger.debug(
-                        f"Module {module_name}:{stream} enabled but not installed, "
+                        f"Module {module_name}:{stream} enabled, "
                         f"marked for package verification ({len(expected_packages)} packages)"
                     )
                     continue

--- a/tests/v1/lifecycle/app_streams/test_app_streams.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams.py
@@ -122,27 +122,39 @@ def test_get_app_stream_module_info_not_found(api_prefix, client, version):
 
 
 @pytest.mark.parametrize(
-    "dnf_modules, os_major, expected_names",
+    "dnf_modules, os_major, expected_names, expected_pending",
     (
         # RHEL 8
-        ([{"name": "python36", "status": ["default"], "stream": "3.6"}], 8, set()),
-        ([{"name": "python36", "status": ["default", "enabled", "installed"], "stream": "3.6"}], 8, {"python36"}),
+        ([{"name": "python36", "status": ["default"], "stream": "3.6"}], 8, set(), set()),
+        (
+            [{"name": "python36", "status": ["default", "enabled", "installed"], "stream": "3.6"}],
+            8,
+            set(),
+            {"python36"},
+        ),  # Enabled modules always go to package verification
         (
             [{"name": "python36", "status": ["default", "enabled"], "stream": "3.6"}],
             8,
             set(),
-        ),  # Enabled-only requires package verification
-        ([{"name": "python36", "status": ["default", "installed"], "stream": "3.6"}], 8, {"python36"}),
-        ([{"name": "python36", "stream": "3.6"}], 8, set()),
+            {"python36"},
+        ),  # Enabled-only also goes to package verification
+        ([{"name": "python36", "status": ["default", "installed"], "stream": "3.6"}], 8, {"python36"}, set()),
+        ([{"name": "python36", "stream": "3.6"}], 8, set(), set()),
         # RHEL 9
-        ([{"name": "php", "status": ["default"], "stream": "8.3"}], 9, set()),
+        ([{"name": "php", "status": ["default"], "stream": "8.3"}], 9, set(), set()),
         (
             [{"name": "php", "status": ["default", "enabled"], "stream": "8.3"}],
             9,
             set(),
-        ),  # Enabled-only requires package verification
-        ([{"name": "php", "status": ["installed", "enabled"], "stream": "8.3"}], 9, {"php"}),
-        ([{"name": "php", "stream": "8.3"}], 9, {"php"}),
+            {"php"},
+        ),  # Enabled-only goes to package verification
+        (
+            [{"name": "php", "status": ["installed", "enabled"], "stream": "8.3"}],
+            9,
+            set(),
+            {"php"},
+        ),  # Enabled+installed also goes to package verification (dnf remove doesn't update module status)
+        ([{"name": "php", "stream": "8.3"}], 9, {"php"}, set()),
     ),
     ids=(
         "RHEL 8 default",
@@ -156,11 +168,15 @@ def test_get_app_stream_module_info_not_found(api_prefix, client, version):
         "RHEL 9 no status",
     ),
 )
-def test_app_streams_from_modules_status_field(dnf_modules, os_major, expected_names):
-    streams = app_streams_from_modules(dnf_modules, os_major, {}, {})
+def test_app_streams_from_modules_status_field(dnf_modules, os_major, expected_names, expected_pending):
+    pending = {}
+    streams = app_streams_from_modules(dnf_modules, os_major, {}, pending)
 
     stream_names = {stream.name for stream in streams}
     assert stream_names == expected_names
+
+    pending_names = {key[0] for key in pending}
+    assert pending_names == expected_pending
 
 
 def test_relevant_app_streams_with_enabled_module_verification(api_prefix, client):


### PR DESCRIPTION
RSPEED-3175

Update the module detection as the installed status can be stale. For example by doing this workflow:
```
sudo dnf module enable mariadb:11.8

# At this point the module is enabled but without packages, is not being reported

sudo dnf module install mariadb:11.8

# The module is not enabled and installed, it also installed the packages so we report it

sudo dnf remove mariadb

# We only removed the packages, the module is still reported as enabled and installed, it is being displayed

sudo dnf module uninstall mariadb:11.8

# The module is now only enabled, we no longer display it
```

With this update, we always display modules when they have a "positive status" (enabled or installed). Modules with "negative status" (disabled) are not reported by Insights so it is a technical limitation outside scope.