### PR TITLE
Fix: Add filtering roadmap notification

### DIFF
--- a/src/notificator/notificator.py
+++ b/src/notificator/notificator.py
@@ -214,6 +214,9 @@ class Notificator:
         cutoff = _upcoming_cutoff_date(today)
         counts: Counter[str] = Counter()
 
+        # Filter out upcoming to keep only relevant
+        upcoming_with_hosts = [item for item in upcoming_with_hosts if item.details.potentiallyAffectedSystemsDetail]
+
         for item in upcoming_with_hosts:
             if item.details.deployedDate is None:
                 # Item was not released yet, let's use today's date for testing

--- a/tests/notificator/test_notificator.py
+++ b/tests/notificator/test_notificator.py
@@ -517,3 +517,15 @@ class TestGetRelevantUpcoming:
         result = await notificator.get_relevant_upcoming(hosts=[])
 
         assert result == Counter({"addition": 1, "change": 1})
+
+    async def test_items_without_affected_systems_excluded(self, notificator):
+        """Items with no affected systems are filtered out before counting."""
+        self.mock_get_upcoming.return_value = [
+            make_upcoming_output("addition", date(2026, 4, 10)),
+            make_upcoming_output("addition", date(2026, 4, 12), affected_systems=set()),
+            make_upcoming_output("deprecation", date(2026, 4, 15), affected_systems=set()),
+        ]
+
+        result = await notificator.get_relevant_upcoming(hosts=[])
+
+        assert result == Counter({"addition": 1})

--- a/tests/notificator/utils.py
+++ b/tests/notificator/utils.py
@@ -136,7 +136,7 @@ def make_upcoming_output(upcoming_type, deployed_date, name="test-item", affecte
         deployedDate=deployed_date,
         potentiallyAffectedSystemsCount=len(affected_systems),
         potentiallyAffectedSystemsDetail=affected_systems,
-        potentiallyAffectedSystems=affected_systems,
+        potentiallyAffectedSystems={s.id for s in affected_systems},
     )
     return UpcomingOutput.model_construct(
         name=name,

--- a/tests/notificator/utils.py
+++ b/tests/notificator/utils.py
@@ -119,8 +119,13 @@ def make_system(name, status, count, major, minor=None):
     )
 
 
-def make_upcoming_output(upcoming_type, deployed_date, name="test-item"):
-    """Build an UpcomingOutput with a given type and deployedDate, bypassing validators."""
+def make_upcoming_output(upcoming_type, deployed_date, name="test-item", affected_systems=None):
+    """Build an UpcomingOutput with a given type and deployedDate, bypassing validators.
+
+    By default the item is created with one affected system so it passes the inventory filter.
+    """
+    if affected_systems is None:
+        affected_systems = {make_system_info(1)}
     details = UpcomingOutputDetails.model_construct(
         architecture=None,
         detailFormat=0,
@@ -129,9 +134,9 @@ def make_upcoming_output(upcoming_type, deployed_date, name="test-item"):
         dateAdded=deployed_date,
         lastModified=deployed_date,
         deployedDate=deployed_date,
-        potentiallyAffectedSystemsCount=0,
-        potentiallyAffectedSystemsDetail=set(),
-        potentiallyAffectedSystems=set(),
+        potentiallyAffectedSystemsCount=len(affected_systems),
+        potentiallyAffectedSystemsDetail=affected_systems,
+        potentiallyAffectedSystems=affected_systems,
     )
     return UpcomingOutput.model_construct(
         name=name,


### PR DESCRIPTION
Originally roadmap notification returned all upcoming changes which were added in the last month to date. Without filtering what's relevant and what's not.

Now the filter is added.