### PR TITLE
Revert notification schedule

### DIFF
--- a/deploy/config.yml
+++ b/deploy/config.yml
@@ -397,7 +397,7 @@ parameters:
     value: '1'
 
   - name: NOTIFICATOR_SCHEDULE
-    value: "0 6 * * *"
+    value: "0 6 1 * *"
 
   - name: CPU_REQUEST_NOTIFICATOR
     value: 500m


### PR DESCRIPTION
After testing, we can revert notification schedule to 1st day of every month at 6 AM UTC.