### PR TITLE
[RHINENG-28543] Module package match improvement

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   notify:
-    after_n_builds: 2
+    after_n_builds: 3
     wait_for_ci: false
 
   require_ci_to_pass: false

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -389,10 +389,17 @@ async def systems_by_app_stream(
             systems_by_stream[app_stream].add(system_info)
 
         # Verify enabled-only modules marked for package verification (only for THIS system)
-        for app_stream_key, expected_packages in modules_pending_verification.values():
-            # Check if this module's expected packages are installed on this system
-            if expected_packages & installed_package_names:
-                # At least one package from the module is installed
+        for cache_key, (app_stream_key, expected_packages) in modules_pending_verification.items():
+            module_name = cache_key[0]
+
+            # To reduce false positives from shared packages (e.g., jansi in both scala and maven),
+            # require the primary package (same name as module) to be installed if it exists
+            if module_name in expected_packages:
+                # Module has a primary package - only count if it's installed
+                if module_name in installed_package_names:
+                    systems_by_stream[app_stream_key].add(system_info)
+            elif expected_packages & installed_package_names:
+                # No primary package exists for this module, check for any package match
                 systems_by_stream[app_stream_key].add(system_info)
                 logger.debug(
                     f"Verified module {app_stream_key.name} on system {system_info.display_name}: "

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -343,6 +343,29 @@ def related_app_streams(app_streams: t.Iterable[AppStreamKey]) -> set[AppStreamK
     return relateds.difference(app_streams)
 
 
+def _verify_pending_modules(
+    modules_pending_verification: dict[tuple[str, int, str], tuple[AppStreamKey, set[str]]],
+    installed_package_names: set[str],
+    system_info: SystemInfo,
+    systems_by_stream: defaultdict[AppStreamKey, set[SystemInfo]],
+) -> None:
+    """Verify enabled-only modules by checking if expected packages are installed."""
+    for cache_key, (app_stream_key, expected_packages) in modules_pending_verification.items():
+        module_name = cache_key[0]
+
+        # To reduce false positives from shared packages (e.g., jansi in both scala and maven),
+        # require the primary package (same name as module) to be installed if it exists
+        if module_name in expected_packages:
+            if module_name in installed_package_names:
+                systems_by_stream[app_stream_key].add(system_info)
+        elif expected_packages & installed_package_names:
+            systems_by_stream[app_stream_key].add(system_info)
+            logger.debug(
+                f"Verified module {app_stream_key.name} on system {system_info.display_name}: "
+                f"{len(expected_packages & installed_package_names)} packages installed"
+            )
+
+
 async def systems_by_app_stream(
     org_id: t.Annotated[str, Depends(decode_header)],
     systems: t.Annotated[AsyncResult, Depends(query_host_inventory)],
@@ -388,23 +411,7 @@ async def systems_by_app_stream(
         for app_stream in module_app_streams:
             systems_by_stream[app_stream].add(system_info)
 
-        # Verify enabled-only modules marked for package verification (only for THIS system)
-        for cache_key, (app_stream_key, expected_packages) in modules_pending_verification.items():
-            module_name = cache_key[0]
-
-            # To reduce false positives from shared packages (e.g., jansi in both scala and maven),
-            # require the primary package (same name as module) to be installed if it exists
-            if module_name in expected_packages:
-                # Module has a primary package - only count if it's installed
-                if module_name in installed_package_names:
-                    systems_by_stream[app_stream_key].add(system_info)
-            elif expected_packages & installed_package_names:
-                # No primary package exists for this module, check for any package match
-                systems_by_stream[app_stream_key].add(system_info)
-                logger.debug(
-                    f"Verified module {app_stream_key.name} on system {system_info.display_name}: "
-                    f"{len(expected_packages & installed_package_names)} packages installed"
-                )
+        _verify_pending_modules(modules_pending_verification, installed_package_names, system_info, systems_by_stream)
 
     # Now process the packages outside of the host record loop
     for args, systems_info in package_data.items():

--- a/tests/v1/lifecycle/app_streams/test_app_streams.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams.py
@@ -412,3 +412,59 @@ async def test_systems_by_app_stream_primary_package_verification():
         f"scala should NOT be detected (enabled but scala package not installed, "
         f"only shared packages like jansi). Got: {module_names}"
     )
+
+
+@pytest.mark.asyncio
+async def test_systems_by_app_stream_no_primary_package_module():
+    """Test module detection when the module has no primary package.
+
+    Some modules (e.g. container-tools) have no package matching the module
+    name. In that case, any matching expected package should be enough to
+    verify the module is in use.
+    """
+    systems_data = [
+        {
+            "id": "44444444-4444-4444-4444-444444444444",
+            "display_name": "test-container-tools",
+            "os_major": 8,
+            "os_minor": 10,
+            "dnf_modules": [
+                {"name": "container-tools", "status": ["enabled"], "stream": "rhel8"},
+            ],
+            "packages": [
+                "podman-4.9.4-1.el8.x86_64",
+                "buildah-1.33.7-1.el8.x86_64",
+                "bash-4.4.20-1.el8.x86_64",
+            ],
+        },
+    ]
+
+    class MockAsyncMappingsIterator:
+        def __init__(self, data):
+            self.data = data
+
+        def mappings(self):
+            return self
+
+        async def __aiter__(self):
+            for system in self.data:
+                yield system
+
+    class MockAsyncResult:
+        def __init__(self, data):
+            self.data = data
+
+        def yield_per(self, batch_size):
+            return MockAsyncMappingsIterator(self.data)
+
+        def mappings(self):
+            return self
+
+    mock_systems = MockAsyncResult(systems_data)
+    result = await systems_by_app_stream("test-org", mock_systems)
+    module_names = {key.name for key in result.keys()}
+
+    assert "container-tools" in module_names, (
+        f"container-tools should be detected (enabled, no primary package, "
+        f"but podman/buildah installed). Got: {module_names}"
+    )

--- a/tests/v1/lifecycle/app_streams/test_app_streams.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams.py
@@ -329,6 +329,10 @@ async def test_systems_by_app_stream_verification_loop():
     with patch("roadmap.v1.lifecycle.app_streams.MODULE_PACKAGES", patched_mp):
         result = await systems_by_app_stream("test-org", mock_systems)
 
+    # Verify results
+    # - python36 should be detected (enabled + python36 primary package installed) <- HITS LINES 391-403
+    # - nodejs should NOT be detected (enabled but nodejs primary package not installed)
+    # - postgresql should be detected (installed status)
     module_names = {key.name for key in result.keys()}
 
     assert "python36" in module_names, f"python36 should be detected (enabled + packages). Got: {module_names}"
@@ -343,3 +347,68 @@ async def test_systems_by_app_stream_verification_loop():
 
     assert len(result[python36_key]) == 1, "python36 should have 1 system"
     assert len(result[postgresql_key]) == 1, "postgresql should have 1 system"
+
+
+@pytest.mark.asyncio
+async def test_systems_by_app_stream_primary_package_verification():
+    """Test that modules with shared packages require the primary package.
+
+    Scala and Maven share packages like jansi and hawtjni. If a system has
+    Maven installed (with jansi) and Scala enabled (but not installed),
+    the old logic would incorrectly detect Scala. The new logic requires
+    the primary package (scala) to be present.
+    """
+    systems_data = [
+        # System with Maven installed and Scala enabled (but not installed)
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "display_name": "test-maven-not-scala",
+            "os_major": 8,
+            "os_minor": 10,
+            "dnf_modules": [
+                {"name": "maven", "status": ["installed", "enabled"], "stream": "3.5"},
+                {"name": "scala", "status": ["enabled"], "stream": "2.10"},  # Enabled but not installed
+            ],
+            "packages": [
+                "maven-3.5.4-1.el8.noarch",  # Primary maven package
+                "jansi-1.17.1-1.el8.noarch",  # Shared with scala
+                "hawtjni-runtime-1.16-1.el8.noarch",  # Shared with scala
+                "bash-4.4.20-1.el8.x86_64",
+            ],
+        },
+    ]
+
+    class MockAsyncMappingsIterator:
+        def __init__(self, data):
+            self.data = data
+
+        def mappings(self):
+            return self
+
+        async def __aiter__(self):
+            for system in self.data:
+                yield system
+
+    class MockAsyncResult:
+        def __init__(self, data):
+            self.data = data
+
+        def yield_per(self, batch_size):
+            return MockAsyncMappingsIterator(self.data)
+
+        def mappings(self):
+            return self
+
+    mock_systems = MockAsyncResult(systems_data)
+    result = await systems_by_app_stream("test-org", mock_systems)
+    module_names = {key.name for key in result.keys()}
+
+    # Maven should be detected (installed status)
+    assert "maven" in module_names, f"maven should be detected (installed). Got: {module_names}"
+
+    # Scala should NOT be detected - even though jansi is installed,
+    # the primary 'scala' package is not present
+    assert "scala" not in module_names, (
+        f"scala should NOT be detected (enabled but scala package not installed, "
+        f"only shared packages like jansi). Got: {module_names}"
+    )


### PR DESCRIPTION
**Problem**
Modules that share packages were causing false positive detections. For example, Scala was incorrectly detected as "enabled" when only Maven was installed, because both modules include the jansi package.

Shared packages between scala and maven:

- jansi
- jansi-native
- hawtjni
- hawtjni-runtime

When a system had Maven installed (with jansi) and Scala enabled (but not actually installed), the verification logic would see jansi and incorrectly conclude that Scala was in use.

**Solution**
Updated the package verification logic in app_streams.py to require the primary package (package with the same name as the module) when it exists:

If module has a primary package (e.g., scala for scala module, maven for maven module)

→ Only detect the module if that primary package is installed

If no primary package exists (e.g., container-tools)

→ Use the existing logic (detect if any package from the module is installed)

This approach:

✅ Eliminates false positives for modules with shared packages
✅ Preserves correct detection for modules without primary packages
✅ Maintains backward compatibility
Analysis
Out of 95 RHEL 8 modules in our dataset:

87 modules (92%) have primary packages → will use strict verification
8 modules (8%) have no primary package → will use permissive verification
The 8 modules without primary packages:

389-ds, container-tools (all streams), idm (all streams), javapackages-runtime, pki-deps, python27, rhn-tools, satellite-5-client, virt

Jira: [RHINENG-28543](https://issues.redhat.com/browse/RHINENG-28543)

[RHINENG-28543]: https://redhat.atlassian.net/browse/RHINENG-28543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ