### PR TITLE
[RHINENG-28540] Use deterministic UUID

### DIFF
--- a/src/notificator/notificator.py
+++ b/src/notificator/notificator.py
@@ -7,7 +7,8 @@ from datetime import date
 from datetime import datetime
 from datetime import timedelta
 from datetime import UTC
-from uuid import uuid4
+from uuid import UUID
+from uuid import uuid5
 
 import structlog
 
@@ -26,6 +27,26 @@ logger = structlog.get_logger(__name__)
 
 
 NOTIFY_STATUSES = {SupportStatus.retired, SupportStatus.near_retirement}
+
+# Random UUID for Insights Planning
+# generated using `python -c "import uuid; print(uuid.uuid4())"`
+NOTIFICATION_NAMESPACE = UUID("e0d6dbe4-7b1b-411b-8017-24edac0ce3cd")
+
+
+def _make_notification_uuid(
+    application: str,
+    event_type: str,
+    org_id: str,
+    day: date,
+) -> UUID:
+    """Generate a deterministic UUID v5 for a notification.
+
+    The same combination of application, event_type, org_id and calendar day
+    always produces the same UUID, which lets the notification backend
+    deduplicate repeated deliveries for the same report.
+    """
+    name = f"{day.isoformat()}:{application}:{event_type}:{org_id}"
+    return uuid5(NOTIFICATION_NAMESPACE, name)
 
 
 class Notificator:
@@ -316,7 +337,7 @@ def _build_roadmap_notification_payload(
 
     return {
         "version": "v1.0.0",
-        "id": str(uuid4()),
+        "id": str(_make_notification_uuid(application, event_type, org_id, day=now.date())),
         "bundle": bundle,
         "application": application,
         "event_type": event_type,
@@ -386,7 +407,7 @@ def _build_lifecycle_notification_payload(
 
     return {
         "version": "v1.0.0",
-        "id": str(uuid4()),
+        "id": str(_make_notification_uuid(application, event_type, org_id, day=now.date())),
         "bundle": bundle,
         "application": application,
         "event_type": event_type,

--- a/tests/notificator/conftest.py
+++ b/tests/notificator/conftest.py
@@ -4,7 +4,6 @@ from notificator.notificator import Notificator
 from roadmap.config import Settings
 
 from .utils import FIXED_DATETIME
-from .utils import FIXED_UUID
 from .utils import ORG_ID
 
 
@@ -17,8 +16,7 @@ def clear_settings_cache():
 
 @pytest.fixture
 def mock_deterministic(mocker):
-    """Pin uuid4 and datetime.now to fixed values for deterministic assertions."""
-    mocker.patch("notificator.notificator.uuid4", return_value=FIXED_UUID)
+    """Pin datetime.now to a fixed value for deterministic assertions."""
     mock_dt = mocker.patch("notificator.notificator.datetime")
     mock_dt.now.return_value = FIXED_DATETIME
 

--- a/tests/notificator/test_notificator.py
+++ b/tests/notificator/test_notificator.py
@@ -8,6 +8,7 @@ import pytest
 
 from notificator.notificator import _build_lifecycle_notification_payload
 from notificator.notificator import _build_roadmap_notification_payload
+from notificator.notificator import _make_notification_uuid
 from notificator.notificator import _upcoming_cutoff_date
 from roadmap.models import Meta
 from roadmap.models import SupportStatus
@@ -15,8 +16,8 @@ from roadmap.v1.lifecycle.rhel import RelevantSystemsResponse
 
 from .utils import EMPTY_APPSTREAM_SECTIONS
 from .utils import EMPTY_RHEL_SECTIONS
+from .utils import FIXED_DATETIME
 from .utils import FIXED_TIMESTAMP
-from .utils import FIXED_UUID
 from .utils import make_appstream_key
 from .utils import make_system
 from .utils import make_system_info
@@ -295,8 +296,14 @@ class TestNotificator:
             application="life-cycle",
         )
 
+        expected_id = str(
+            _make_notification_uuid(
+                "life-cycle", "retiring-lifecycle-monthly-report", str(ORG_ID), FIXED_DATETIME.date()
+            )
+        )
+
         assert result["version"] == "v1.0.0"
-        assert result["id"] == str(FIXED_UUID)
+        assert result["id"] == expected_id
         assert result["bundle"] == "rhel"
         assert result["application"] == "life-cycle"
         assert result["event_type"] == "retiring-lifecycle-monthly-report"
@@ -346,6 +353,28 @@ class TestNotificator:
         }
 
 
+class TestMakeNotificationUuid:
+    """_make_notification_uuid: deterministic UUID v5 generation for notifications."""
+
+    def test_same_inputs_produce_same_uuid(self):
+        first = _make_notification_uuid("life-cycle", "retiring-lifecycle-monthly-report", "1234", date(2026, 7, 16))
+        second = _make_notification_uuid("life-cycle", "retiring-lifecycle-monthly-report", "1234", date(2026, 7, 16))
+
+        assert first == second
+
+    def test_different_day_produces_different_uuid(self):
+        uuid_a = _make_notification_uuid("life-cycle", "retiring-lifecycle-monthly-report", "1234", date(2026, 7, 16))
+        uuid_b = _make_notification_uuid("life-cycle", "retiring-lifecycle-monthly-report", "1234", date(2026, 7, 17))
+
+        assert uuid_a != uuid_b
+
+    def test_different_org_produces_different_uuid(self):
+        uuid_a = _make_notification_uuid("life-cycle", "retiring-lifecycle-monthly-report", "1234", date(2026, 7, 16))
+        uuid_b = _make_notification_uuid("life-cycle", "retiring-lifecycle-monthly-report", "5678", date(2026, 7, 16))
+
+        assert uuid_a != uuid_b
+
+
 class TestUpcomingCutoffDate:
     """_upcoming_cutoff_date: returns first of previous month for the reporting window."""
 
@@ -373,8 +402,12 @@ class TestBuildRoadmapNotificationPayload:
 
         result = _build_roadmap_notification_payload(upcoming_counts=counts, org_id=str(ORG_ID))
 
+        expected_id = str(
+            _make_notification_uuid("roadmap", "roadmap-monthly-report", str(ORG_ID), FIXED_DATETIME.date())
+        )
+
         assert result["version"] == "v1.0.0"
-        assert result["id"] == str(FIXED_UUID)
+        assert result["id"] == expected_id
         assert result["bundle"] == "rhel"
         assert result["application"] == "roadmap"
         assert result["event_type"] == "roadmap-monthly-report"


### PR DESCRIPTION
Use deterministic UUID for the same day. In case of failure,
notification generated multiple times on the same day will be sent only
once to customers because of filtering on notification backend side.
    
There is a 24h window where the UUID is tracked on notification side.
This window can be extended if needed.