### PR TITLE
[RHINENG-28540] Add dryrun for admin endpoint

### DIFF
--- a/src/notificator/lifecycle.py
+++ b/src/notificator/lifecycle.py
@@ -11,8 +11,8 @@ from notificator.subscriptions import get_org_ids
 logger = structlog.get_logger(__name__)
 
 
-async def lifecycle_notification(override_org_ids: list[int] | None = None):
-    logger.info("Started lifecycle notification")
+async def lifecycle_notification(override_org_ids: list[int] | None = None, *, dry_run: bool = False):
+    logger.info("Started lifecycle notification", dry_run=dry_run)
     lifecycle_notification_start_time = time.time()
     try:
         org_ids = override_org_ids if override_org_ids is not None else await get_org_ids(LIFECYCLE_SUBSCRIPTION)
@@ -34,7 +34,10 @@ async def lifecycle_notification(override_org_ids: list[int] | None = None):
                     n = Notificator(org_id=org_id)
                     payload = await n.get_lifecycle_notification()
                     logger.debug("Payload generated", org_id=org_id, payload=payload)
-                    await producer.send_notification(payload)
+                    if dry_run:
+                        logger.info("Dry run: skipping send", org_id=org_id, payload=payload)
+                    else:
+                        await producer.send_notification(payload)
                     elapsed = time.time() - start_time
                     logger.info("Lifecycle notification completed", org_id=org_id, duration_seconds=round(elapsed, 2))
                 # Wide exception, we don't want one failed ORG_ID causing failure of the whole script.
@@ -53,6 +56,7 @@ async def lifecycle_notification(override_org_ids: list[int] | None = None):
         "Finished lifecycle notification",
         duration_seconds=lifecycle_notification_elapsed,
         processed_org_ids=len(org_ids),
+        dry_run=dry_run,
     )
 
     if failed_orgs:

--- a/src/notificator/roadmap.py
+++ b/src/notificator/roadmap.py
@@ -11,8 +11,8 @@ from notificator.subscriptions import get_org_ids
 logger = structlog.get_logger(__name__)
 
 
-async def roadmap_notification(override_org_ids: list[int] | None = None):
-    logger.info("Started roadmap notification")
+async def roadmap_notification(override_org_ids: list[int] | None = None, *, dry_run: bool = False):
+    logger.info("Started roadmap notification", dry_run=dry_run)
     roadmap_notification_start_time = time.time()
     try:
         org_ids = override_org_ids if override_org_ids is not None else await get_org_ids(ROADMAP_SUBSCRIPTION)
@@ -34,7 +34,10 @@ async def roadmap_notification(override_org_ids: list[int] | None = None):
                     n = Notificator(org_id=org_id)
                     payload = await n.get_roadmap_notification()
                     logger.debug("Payload generated", org_id=org_id, payload=payload)
-                    await producer.send_notification(payload)
+                    if dry_run:
+                        logger.info("Dry run: skipping send", org_id=org_id, payload=payload)
+                    else:
+                        await producer.send_notification(payload)
                     elapsed = time.time() - start_time
                     logger.info("Roadmap notification completed", org_id=org_id, duration_seconds=round(elapsed, 2))
                 # Wide exception, we don't want one failed ORG_ID causing failure of the whole script.
@@ -53,6 +56,7 @@ async def roadmap_notification(override_org_ids: list[int] | None = None):
         "Finished roadmap notification",
         duration_seconds=roadmap_notification_elapsed,
         processed_org_ids=len(org_ids),
+        dry_run=dry_run,
     )
 
     if failed_orgs:

--- a/src/roadmap/admin/notifications/__init__.py
+++ b/src/roadmap/admin/notifications/__init__.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter
 from fastapi import BackgroundTasks
 from fastapi import Body
 from fastapi import HTTPException
+from fastapi import Query
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import field_validator
@@ -80,19 +81,21 @@ def build_notification_router(kind: NotificationKind) -> APIRouter:
     router = APIRouter()
     prefix = f"/notifications/{kind.label}"
 
-    async def _trigger(org_ids: list[int] | None = None):
-        logger.info(f"Admin trigger: {kind.label} notification", org_ids=org_ids, total_orgs=len(org_ids or []))
+    async def _trigger(org_ids: list[int] | None = None, *, dry_run: bool = False):
+        logger.info(
+            f"Admin trigger: {kind.label} notification", org_ids=org_ids, total_orgs=len(org_ids or []), dry_run=dry_run
+        )
         try:
-            await kind.send(override_org_ids=org_ids)
+            await kind.send(override_org_ids=org_ids, dry_run=dry_run)
         except KafkaBrokersNotConfigured as exc:
             logger.error("Kafka brokers not configured")
             raise HTTPException(status_code=503, detail="Kafka brokers not configured") from exc
         except RuntimeError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    async def _trigger_background(org_ids: list[int] | None = None):
+    async def _trigger_background(org_ids: list[int] | None = None, *, dry_run: bool = False):
         try:
-            await _trigger(org_ids=org_ids)
+            await _trigger(org_ids=org_ids, dry_run=dry_run)
         except Exception as exc:
             logger.exception(
                 f"Admin trigger: Unexpected background {kind.label} notification failure",
@@ -114,20 +117,32 @@ def build_notification_router(kind: NotificationKind) -> APIRouter:
         return {"org_ids": org_ids, "count": len(org_ids)}
 
     @router.post(f"{prefix}/custom", summary=f"Trigger {kind.label} notification for one or more orgs", status_code=202)
-    async def trigger_custom(background_tasks: BackgroundTasks, payload: CustomNotificatorRequest = Body(...)):
+    async def trigger_custom(
+        background_tasks: BackgroundTasks,
+        payload: CustomNotificatorRequest = Body(...),
+        dry_run: bool = Query(default=True, alias="dryrun"),
+    ):
         org_ids = [payload.org_ids] if isinstance(payload.org_ids, int) else payload.org_ids
         unique_org_ids = sorted(set(org_ids))
-        background_tasks.add_task(_trigger_background, org_ids=unique_org_ids)
-        return {"message": f"{kind.label.capitalize()} notification accepted", "requested_org_ids": unique_org_ids}
+        background_tasks.add_task(_trigger_background, org_ids=unique_org_ids, dry_run=dry_run)
+        return {
+            "message": f"{kind.label.capitalize()} notification accepted",
+            "requested_org_ids": unique_org_ids,
+            "dry_run": dry_run,
+        }
 
     @router.post(f"{prefix}/all", summary=f"Trigger {kind.label} notification for all orgs", status_code=202)
-    async def trigger_all(background_tasks: BackgroundTasks, payload: AllNotificatorRequest = Body(...)):
+    async def trigger_all(
+        background_tasks: BackgroundTasks,
+        payload: AllNotificatorRequest = Body(...),
+        dry_run: bool = Query(default=True, alias="dryrun"),
+    ):
         if not payload.confirm_all:
             raise HTTPException(
                 status_code=400,
                 detail="Set confirm_all=true to trigger notifications for all orgs.",
             )
-        background_tasks.add_task(_trigger_background)
-        return {"message": f"{kind.label.capitalize()} notification accepted"}
+        background_tasks.add_task(_trigger_background, dry_run=dry_run)
+        return {"message": f"{kind.label.capitalize()} notification accepted", "dry_run": dry_run}
 
     return router

--- a/tests/admin/test_notifications.py
+++ b/tests/admin/test_notifications.py
@@ -186,38 +186,39 @@ class TestTriggerNotification:
     """Custom and broadcast trigger endpoints, parametrized over lifecycle and roadmap."""
 
     def test_custom_success_single_org(self, admin_client, endpoints):
-        response = admin_client.post(endpoints.custom_url, json={"org_ids": 42})
+        response = admin_client.post(f"{endpoints.custom_url}?dryrun=false", json={"org_ids": 42})
 
         assert response.status_code == 202
         body = response.json()
         assert body == {
             "message": f"{endpoints.label.capitalize()} notification accepted",
             "requested_org_ids": [42],
+            "dry_run": False,
         }
-        endpoints.mock_send.assert_awaited_once_with(override_org_ids=[42])
+        endpoints.mock_send.assert_awaited_once_with(override_org_ids=[42], dry_run=False)
 
     def test_custom_deduplicates_and_sorts_org_ids(self, admin_client, endpoints):
-        response = admin_client.post(endpoints.custom_url, json={"org_ids": [3, 1, 3, 2]})
+        response = admin_client.post(f"{endpoints.custom_url}?dryrun=false", json={"org_ids": [3, 1, 3, 2]})
 
         assert response.status_code == 202
         assert response.json()["requested_org_ids"] == [1, 2, 3]
-        endpoints.mock_send.assert_awaited_once_with(override_org_ids=[1, 2, 3])
+        endpoints.mock_send.assert_awaited_once_with(override_org_ids=[1, 2, 3], dry_run=False)
 
     def test_custom_background_failure_still_returns_202(self, admin_client, endpoints):
         endpoints.mock_send.side_effect = RuntimeError("failed for 1/1 orgs")
 
-        response = admin_client.post(endpoints.custom_url, json={"org_ids": 42})
+        response = admin_client.post(f"{endpoints.custom_url}?dryrun=false", json={"org_ids": 42})
 
         assert response.status_code == 202
-        endpoints.mock_send.assert_awaited_once_with(override_org_ids=[42])
+        endpoints.mock_send.assert_awaited_once_with(override_org_ids=[42], dry_run=False)
 
     def test_custom_kafka_not_configured_still_returns_202(self, admin_client, endpoints):
         endpoints.mock_send.side_effect = KafkaBrokersNotConfigured("no brokers")
 
-        response = admin_client.post(endpoints.custom_url, json={"org_ids": 42})
+        response = admin_client.post(f"{endpoints.custom_url}?dryrun=false", json={"org_ids": 42})
 
         assert response.status_code == 202
-        endpoints.mock_send.assert_awaited_once_with(override_org_ids=[42])
+        endpoints.mock_send.assert_awaited_once_with(override_org_ids=[42], dry_run=False)
 
     def test_all_requires_confirmation(self, admin_client, endpoints):
         response = admin_client.post(endpoints.all_url, json={"confirm_all": False})
@@ -226,19 +227,22 @@ class TestTriggerNotification:
         assert "confirm_all=true" in response.json()["detail"]
 
     def test_all_accepts_and_triggers_background(self, admin_client, endpoints):
-        response = admin_client.post(endpoints.all_url, json={"confirm_all": True})
+        response = admin_client.post(f"{endpoints.all_url}?dryrun=false", json={"confirm_all": True})
 
         assert response.status_code == 202
-        assert response.json() == {"message": f"{endpoints.label.capitalize()} notification accepted"}
-        endpoints.mock_send.assert_awaited_once_with(override_org_ids=None)
+        assert response.json() == {
+            "message": f"{endpoints.label.capitalize()} notification accepted",
+            "dry_run": False,
+        }
+        endpoints.mock_send.assert_awaited_once_with(override_org_ids=None, dry_run=False)
 
     def test_all_background_failure_still_returns_202(self, admin_client, endpoints):
         endpoints.mock_send.side_effect = RuntimeError("batch failed")
 
-        response = admin_client.post(endpoints.all_url, json={"confirm_all": True})
+        response = admin_client.post(f"{endpoints.all_url}?dryrun=false", json={"confirm_all": True})
 
         assert response.status_code == 202
-        endpoints.mock_send.assert_awaited_once_with(override_org_ids=None)
+        endpoints.mock_send.assert_awaited_once_with(override_org_ids=None, dry_run=False)
 
 
 # -- Subscribed orgs endpoint (parametrized) -----------------------------------

--- a/tests/notificator/test__main__.py
+++ b/tests/notificator/test__main__.py
@@ -161,6 +161,16 @@ class TestLifecycleNotification:
         get_mock.assert_not_called()
         assert len(self.producer.sent) == 2
 
+    async def test_dry_run_generates_payload_but_skips_send(self, mocker):
+        """In dry-run mode, payloads are generated but not sent to Kafka."""
+        mock_cls = self._patch_notificator(mocker, [42, 99], return_value={"ok": True})
+        send_spy = mocker.spy(self.producer, "send_notification")
+
+        await lifecycle_notification(dry_run=True)
+
+        assert mock_cls.call_count == 2
+        send_spy.assert_not_called()
+
 
 class TestMain:
     """main(): orchestrates both notification types in order."""

--- a/tests/notificator/test_roadmap.py
+++ b/tests/notificator/test_roadmap.py
@@ -145,3 +145,13 @@ class TestRoadmapNotification:
 
         get_mock.assert_not_called()
         assert len(self.producer.sent) == 2
+
+    async def test_dry_run_generates_payload_but_skips_send(self, mocker):
+        """In dry-run mode, payloads are generated but not sent to Kafka."""
+        mock_cls, _ = self._patch_notificator(mocker, [42, 99], return_value={"ok": True})
+        send_spy = mocker.spy(self.producer, "send_notification")
+
+        await roadmap_notification(dry_run=True)
+
+        assert mock_cls.call_count == 2
+        send_spy.assert_not_called()


### PR DESCRIPTION
Add dryrun for notification admin endpoint to be able to trigger notificator, but without sending the notifications. This helps with testing - logs can be checked later in openshift console.