### PR TITLE
Add a force_email param to the admin API

### DIFF
--- a/src/notificator/lifecycle.py
+++ b/src/notificator/lifecycle.py
@@ -11,8 +11,13 @@ from notificator.subscriptions import get_org_ids
 logger = structlog.get_logger(__name__)
 
 
-async def lifecycle_notification(override_org_ids: list[int] | None = None, *, dry_run: bool = False):
-    logger.info("Started lifecycle notification", dry_run=dry_run)
+async def lifecycle_notification(
+    override_org_ids: list[int] | None = None,
+    *,
+    dry_run: bool = False,
+    force_email: bool = False,
+):
+    logger.info("Started lifecycle notification", dry_run=dry_run, force_email=force_email)
     lifecycle_notification_start_time = time.time()
     try:
         org_ids = override_org_ids if override_org_ids is not None else await get_org_ids(LIFECYCLE_SUBSCRIPTION)
@@ -32,7 +37,7 @@ async def lifecycle_notification(override_org_ids: list[int] | None = None, *, d
                 logger.info("Processing lifecycle notification", org_id=org_id)
                 try:
                     n = Notificator(org_id=org_id)
-                    payload = await n.get_lifecycle_notification()
+                    payload = await n.get_lifecycle_notification(force_email=force_email)
                     logger.debug("Payload generated", org_id=org_id, payload=payload)
                     if dry_run:
                         logger.info("Dry run: skipping send", org_id=org_id, payload=payload)

--- a/src/notificator/notificator.py
+++ b/src/notificator/notificator.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from datetime import timedelta
 from datetime import UTC
 from uuid import UUID
+from uuid import uuid4
 from uuid import uuid5
 
 import structlog
@@ -37,13 +38,21 @@ def _make_notification_uuid(
     event_type: str,
     org_id: str,
     day: date,
+    *,
+    force_email: bool = False,
 ) -> UUID:
     """Generate a deterministic UUID v5 for a notification.
 
     The same combination of application, event_type, org_id and calendar day
     always produces the same UUID, which lets the notification backend
     deduplicate repeated deliveries for the same report.
+
+    When ``force_email`` is true (available on admin API), a random UUID is used
+    so each trigger delivers a fresh email.
     """
+    if force_email:
+        return uuid4()
+
     name = f"{day.isoformat()}:{application}:{event_type}:{org_id}"
     return uuid5(NOTIFICATION_NAMESPACE, name)
 
@@ -172,7 +181,7 @@ class Notificator:
         )
         return rhel_sections
 
-    async def get_lifecycle_notification(self) -> dict:
+    async def get_lifecycle_notification(self, *, force_email: bool = False) -> dict:
         """Gather required information for notification and build kafka message for notification backend.
 
         RHEL and appstream data are each streamed from the database
@@ -189,6 +198,7 @@ class Notificator:
             org_id=str(self.org_id),
             event_type="retiring-lifecycle-monthly-report",
             application="life-cycle",
+            force_email=force_email,
         )
 
         logger.info("Built lifecycle notification", org_id=self.org_id, event_type="retiring-lifecycle-monthly-report")
@@ -260,7 +270,7 @@ class Notificator:
         )
         return counts
 
-    async def get_roadmap_notification(self) -> dict:
+    async def get_roadmap_notification(self, *, force_email: bool = False) -> dict:
         """Gather required information for notification and build kafka message for notification backend.
 
         Host data is streamed from the database so that host rows are never
@@ -273,6 +283,7 @@ class Notificator:
         payload = _build_roadmap_notification_payload(
             upcoming_counts=upcoming_counts,
             org_id=str(self.org_id),
+            force_email=force_email,
         )
 
         logger.info("Built roadmap notification", org_id=self.org_id, event_type="roadmap-monthly-report")
@@ -296,6 +307,8 @@ def _build_roadmap_notification_payload(
     bundle: str = "rhel",
     application: str = "roadmap",
     event_type: str = "roadmap-monthly-report",
+    *,
+    force_email: bool = False,
 ) -> dict:
     """Build kafka message for roadmap notification backend using their specified format.
 
@@ -341,7 +354,7 @@ def _build_roadmap_notification_payload(
 
     return {
         "version": "v1.0.0",
-        "id": str(_make_notification_uuid(application, event_type, org_id, day=now.date())),
+        "id": str(_make_notification_uuid(application, event_type, org_id, day=now.date(), force_email=force_email)),
         "bundle": bundle,
         "application": application,
         "event_type": event_type,
@@ -369,6 +382,8 @@ def _build_lifecycle_notification_payload(
     event_type: str,
     bundle: str = "rhel",
     application: str = "life-cycle",
+    *,
+    force_email: bool = False,
 ) -> dict:
     """Build kafka message for notification backend using their specified format.
 
@@ -411,7 +426,7 @@ def _build_lifecycle_notification_payload(
 
     return {
         "version": "v1.0.0",
-        "id": str(_make_notification_uuid(application, event_type, org_id, day=now.date())),
+        "id": str(_make_notification_uuid(application, event_type, org_id, day=now.date(), force_email=force_email)),
         "bundle": bundle,
         "application": application,
         "event_type": event_type,

--- a/src/notificator/roadmap.py
+++ b/src/notificator/roadmap.py
@@ -11,8 +11,13 @@ from notificator.subscriptions import get_org_ids
 logger = structlog.get_logger(__name__)
 
 
-async def roadmap_notification(override_org_ids: list[int] | None = None, *, dry_run: bool = False):
-    logger.info("Started roadmap notification", dry_run=dry_run)
+async def roadmap_notification(
+    override_org_ids: list[int] | None = None,
+    *,
+    dry_run: bool = False,
+    force_email: bool = False,
+):
+    logger.info("Started roadmap notification", dry_run=dry_run, force_email=force_email)
     roadmap_notification_start_time = time.time()
     try:
         org_ids = override_org_ids if override_org_ids is not None else await get_org_ids(ROADMAP_SUBSCRIPTION)
@@ -32,7 +37,7 @@ async def roadmap_notification(override_org_ids: list[int] | None = None, *, dry
                 logger.info("Processing roadmap notification", org_id=org_id)
                 try:
                     n = Notificator(org_id=org_id)
-                    payload = await n.get_roadmap_notification()
+                    payload = await n.get_roadmap_notification(force_email=force_email)
                     logger.debug("Payload generated", org_id=org_id, payload=payload)
                     if dry_run:
                         logger.info("Dry run: skipping send", org_id=org_id, payload=payload)

--- a/src/roadmap/admin/notifications/__init__.py
+++ b/src/roadmap/admin/notifications/__init__.py
@@ -37,6 +37,10 @@ class CustomNotificatorRequest(BaseModel):
     org_ids: int | list[int] = Field(
         description="A single org ID or a list of org IDs that should receive notifications."
     )
+    force_email: bool = Field(
+        default=False,
+        description="When true, bypass same-day notification dedup so every trigger sends a fresh email.",
+    )
 
     @field_validator("org_ids")
     @classmethod
@@ -55,6 +59,10 @@ class AllNotificatorRequest(BaseModel):
     confirm_all: bool = Field(
         default=False,
         description="Set to true to confirm notifications should be triggered for every org subscribed to receive this type of notification.",
+    )
+    force_email: bool = Field(
+        default=False,
+        description="When true, bypass same-day notification dedup so every trigger sends a fresh email.",
     )
 
 
@@ -81,21 +89,27 @@ def build_notification_router(kind: NotificationKind) -> APIRouter:
     router = APIRouter()
     prefix = f"/notifications/{kind.label}"
 
-    async def _trigger(org_ids: list[int] | None = None, *, dry_run: bool = False):
+    async def _trigger(org_ids: list[int] | None = None, *, dry_run: bool = False, force_email: bool = False):
         logger.info(
-            f"Admin trigger: {kind.label} notification", org_ids=org_ids, total_orgs=len(org_ids or []), dry_run=dry_run
+            f"Admin trigger: {kind.label} notification",
+            org_ids=org_ids,
+            total_orgs=len(org_ids or []),
+            dry_run=dry_run,
+            force_email=force_email,
         )
         try:
-            await kind.send(override_org_ids=org_ids, dry_run=dry_run)
+            await kind.send(override_org_ids=org_ids, dry_run=dry_run, force_email=force_email)
         except KafkaBrokersNotConfigured as exc:
             logger.error("Kafka brokers not configured")
             raise HTTPException(status_code=503, detail="Kafka brokers not configured") from exc
         except RuntimeError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    async def _trigger_background(org_ids: list[int] | None = None, *, dry_run: bool = False):
+    async def _trigger_background(
+        org_ids: list[int] | None = None, *, dry_run: bool = False, force_email: bool = False
+    ):
         try:
-            await _trigger(org_ids=org_ids, dry_run=dry_run)
+            await _trigger(org_ids=org_ids, dry_run=dry_run, force_email=force_email)
         except Exception as exc:
             logger.exception(
                 f"Admin trigger: Unexpected background {kind.label} notification failure",
@@ -123,12 +137,16 @@ def build_notification_router(kind: NotificationKind) -> APIRouter:
         dry_run: bool = Query(default=True, alias="dryrun"),
     ):
         org_ids = [payload.org_ids] if isinstance(payload.org_ids, int) else payload.org_ids
-        unique_org_ids = sorted(set(org_ids))
-        background_tasks.add_task(_trigger_background, org_ids=unique_org_ids, dry_run=dry_run)
+        unique_org_ids = sorted(set[int](org_ids))
+
+        background_tasks.add_task(
+            _trigger_background, org_ids=unique_org_ids, dry_run=dry_run, force_email=payload.force_email
+        )
         return {
             "message": f"{kind.label.capitalize()} notification accepted",
             "requested_org_ids": unique_org_ids,
             "dry_run": dry_run,
+            "force_email": payload.force_email,
         }
 
     @router.post(f"{prefix}/all", summary=f"Trigger {kind.label} notification for all orgs", status_code=202)
@@ -142,7 +160,12 @@ def build_notification_router(kind: NotificationKind) -> APIRouter:
                 status_code=400,
                 detail="Set confirm_all=true to trigger notifications for all orgs.",
             )
-        background_tasks.add_task(_trigger_background, dry_run=dry_run)
-        return {"message": f"{kind.label.capitalize()} notification accepted", "dry_run": dry_run}
+
+        background_tasks.add_task(_trigger_background, dry_run=dry_run, force_email=payload.force_email)
+        return {
+            "message": f"{kind.label.capitalize()} notification accepted",
+            "dry_run": dry_run,
+            "force_email": payload.force_email,
+        }
 
     return router

--- a/tests/admin/test_notifications.py
+++ b/tests/admin/test_notifications.py
@@ -194,15 +194,24 @@ class TestTriggerNotification:
             "message": f"{endpoints.label.capitalize()} notification accepted",
             "requested_org_ids": [42],
             "dry_run": False,
+            "force_email": False,
         }
-        endpoints.mock_send.assert_awaited_once_with(override_org_ids=[42], dry_run=False)
+        endpoints.mock_send.assert_awaited_once_with(override_org_ids=[42], dry_run=False, force_email=False)
+
+    def test_custom_with_force_email(self, admin_client, endpoints):
+        response = admin_client.post(f"{endpoints.custom_url}?dryrun=false", json={"org_ids": 42, "force_email": True})
+
+        assert response.status_code == 202
+        body = response.json()
+        assert body["force_email"] is True
+        endpoints.mock_send.assert_awaited_once_with(override_org_ids=[42], dry_run=False, force_email=True)
 
     def test_custom_deduplicates_and_sorts_org_ids(self, admin_client, endpoints):
         response = admin_client.post(f"{endpoints.custom_url}?dryrun=false", json={"org_ids": [3, 1, 3, 2]})
 
         assert response.status_code == 202
         assert response.json()["requested_org_ids"] == [1, 2, 3]
-        endpoints.mock_send.assert_awaited_once_with(override_org_ids=[1, 2, 3], dry_run=False)
+        endpoints.mock_send.assert_awaited_once_with(override_org_ids=[1, 2, 3], dry_run=False, force_email=False)
 
     def test_custom_background_failure_still_returns_202(self, admin_client, endpoints):
         endpoints.mock_send.side_effect = RuntimeError("failed for 1/1 orgs")
@@ -210,7 +219,7 @@ class TestTriggerNotification:
         response = admin_client.post(f"{endpoints.custom_url}?dryrun=false", json={"org_ids": 42})
 
         assert response.status_code == 202
-        endpoints.mock_send.assert_awaited_once_with(override_org_ids=[42], dry_run=False)
+        endpoints.mock_send.assert_awaited_once_with(override_org_ids=[42], dry_run=False, force_email=False)
 
     def test_custom_kafka_not_configured_still_returns_202(self, admin_client, endpoints):
         endpoints.mock_send.side_effect = KafkaBrokersNotConfigured("no brokers")
@@ -218,7 +227,7 @@ class TestTriggerNotification:
         response = admin_client.post(f"{endpoints.custom_url}?dryrun=false", json={"org_ids": 42})
 
         assert response.status_code == 202
-        endpoints.mock_send.assert_awaited_once_with(override_org_ids=[42], dry_run=False)
+        endpoints.mock_send.assert_awaited_once_with(override_org_ids=[42], dry_run=False, force_email=False)
 
     def test_all_requires_confirmation(self, admin_client, endpoints):
         response = admin_client.post(endpoints.all_url, json={"confirm_all": False})
@@ -233,8 +242,19 @@ class TestTriggerNotification:
         assert response.json() == {
             "message": f"{endpoints.label.capitalize()} notification accepted",
             "dry_run": False,
+            "force_email": False,
         }
-        endpoints.mock_send.assert_awaited_once_with(override_org_ids=None, dry_run=False)
+        endpoints.mock_send.assert_awaited_once_with(override_org_ids=None, dry_run=False, force_email=False)
+
+    def test_all_with_force_email(self, admin_client, endpoints):
+        response = admin_client.post(
+            f"{endpoints.all_url}?dryrun=false", json={"confirm_all": True, "force_email": True}
+        )
+
+        assert response.status_code == 202
+        body = response.json()
+        assert body["force_email"] is True
+        endpoints.mock_send.assert_awaited_once_with(override_org_ids=None, dry_run=False, force_email=True)
 
     def test_all_background_failure_still_returns_202(self, admin_client, endpoints):
         endpoints.mock_send.side_effect = RuntimeError("batch failed")
@@ -242,7 +262,7 @@ class TestTriggerNotification:
         response = admin_client.post(f"{endpoints.all_url}?dryrun=false", json={"confirm_all": True})
 
         assert response.status_code == 202
-        endpoints.mock_send.assert_awaited_once_with(override_org_ids=None, dry_run=False)
+        endpoints.mock_send.assert_awaited_once_with(override_org_ids=None, dry_run=False, force_email=False)
 
 
 # -- Subscribed orgs endpoint (parametrized) -----------------------------------

--- a/tests/notificator/test_notificator.py
+++ b/tests/notificator/test_notificator.py
@@ -328,7 +328,7 @@ class TestNotificator:
 
 
 class TestMakeNotificationUuid:
-    """_make_notification_uuid: deterministic UUID v5 generation for notifications."""
+    """_make_notification_uuid: deterministic by default, random when force_email on non-prod."""
 
     def test_same_inputs_produce_same_uuid(self):
         first = _make_notification_uuid("life-cycle", "retiring-lifecycle-monthly-report", "1234", date(2026, 7, 16))
@@ -347,6 +347,22 @@ class TestMakeNotificationUuid:
         uuid_b = _make_notification_uuid("life-cycle", "retiring-lifecycle-monthly-report", "5678", date(2026, 7, 16))
 
         assert uuid_a != uuid_b
+
+    def test_force_email_produces_different_uuid_each_call(self):
+        first = _make_notification_uuid(
+            "life-cycle", "retiring-lifecycle-monthly-report", "1234", date(2026, 7, 16), force_email=True
+        )
+        second = _make_notification_uuid(
+            "life-cycle", "retiring-lifecycle-monthly-report", "1234", date(2026, 7, 16), force_email=True
+        )
+
+        assert first != second
+
+    def test_without_force_email_still_deduplicates(self):
+        first = _make_notification_uuid("life-cycle", "retiring-lifecycle-monthly-report", "1234", date(2026, 7, 16))
+        second = _make_notification_uuid("life-cycle", "retiring-lifecycle-monthly-report", "1234", date(2026, 7, 16))
+
+        assert first == second
 
 
 class TestUpcomingCutoffDate:


### PR DESCRIPTION
The deterministic UUID PR https://github.com/RedHatInsights/digital-roadmap-backend/pull/383 affects testing as it prevent us from sending multiple emails on a single day. With this PR I add a force_email param that can be set via the admin API and forces the notificator to use a new UUID.