### PR TITLE
[RHINENG-29220] Introduce shared packages & use while matching

### DIFF
--- a/src/roadmap/data/__init__.py
+++ b/src/roadmap/data/__init__.py
@@ -35,7 +35,26 @@ def _only_app_streams(data) -> set[AppStreamEntity]:
     return app_streams
 
 
+def _shared_package_names(module_packages: dict[tuple[str, int, str], set[str]]) -> dict[int, set[str]]:
+    """Return, per RHEL major version, package names referenced by more than one module.
+
+    These are ambiguous signals (e.g. jansi and hawtjni-runtime appear in both
+    scala and maven) and cannot be trusted on their own to verify a module is
+    in use. Packages unique to a single module are trustworthy evidence.
+    """
+    owners_by_os_major: dict[int, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+    for (module_name, os_major, _stream), pkgs in module_packages.items():
+        for pkg in pkgs:
+            owners_by_os_major[os_major][pkg].add(module_name)
+
+    return {
+        os_major: {pkg for pkg, modules in owners.items() if len(modules) > 1}
+        for os_major, owners in owners_by_os_major.items()
+    }
+
+
 APP_STREAM_MODULES_BY_KEY = {(asm.name, asm.os_major, asm.stream): asm for asm in APP_STREAM_MODULES}
 OS_MAJORS_BY_APP_NAME = _os_majors_by_app_name()
 APP_STREAM_MODULES_PACKAGES = _modules_packages()
 APP_STREAMS = _only_app_streams(APP_STREAM_MODULES_PACKAGES)
+SHARED_PACKAGE_NAMES_BY_OS_MAJOR = _shared_package_names(MODULE_PACKAGES)

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -32,6 +32,7 @@ from roadmap.data import APP_STREAM_PACKAGES
 from roadmap.data import APP_STREAMS
 from roadmap.data import MODULE_PACKAGES
 from roadmap.data import OS_MAJORS_BY_APP_NAME
+from roadmap.data import SHARED_PACKAGE_NAMES_BY_OS_MAJOR
 from roadmap.data.app_streams import AppStreamEntity
 from roadmap.data.app_streams import AppStreamImplementation
 from roadmap.data.app_streams import AppStreamType
@@ -351,18 +352,23 @@ def _verify_pending_modules(
 ) -> None:
     """Verify enabled-only modules by checking if expected packages are installed."""
     for cache_key, (app_stream_key, expected_packages) in modules_pending_verification.items():
-        module_name = cache_key[0]
+        module_name, os_major, _stream = cache_key
+        matched_packages = expected_packages & installed_package_names
+        if not matched_packages:
+            continue
 
-        # To reduce false positives from shared packages (e.g., jansi in both scala and maven),
-        # require the primary package (same name as module) to be installed if it exists
-        if module_name in expected_packages:
-            if module_name in installed_package_names:
-                systems_by_stream[app_stream_key].add(system_info)
-        elif expected_packages & installed_package_names:
+        # Packages unique to this module (within the same os_major) are trustworthy on
+        # their own. Only require the primary package (matching the module name) when
+        # every matched package is ambiguous/shared with another module's package list
+        # on the same RHEL major version (e.g. jansi is shared between scala and maven
+        # on RHEL 8).
+        shared_package_names = SHARED_PACKAGE_NAMES_BY_OS_MAJOR.get(os_major, set())
+        unambiguous_matches = matched_packages - shared_package_names
+        if unambiguous_matches or module_name in installed_package_names:
             systems_by_stream[app_stream_key].add(system_info)
             logger.debug(
                 f"Verified module {app_stream_key.name} on system {system_info.display_name}: "
-                f"{len(expected_packages & installed_package_names)} packages installed"
+                f"{len(matched_packages)} packages installed"
             )
 
 

--- a/tests/v1/lifecycle/app_streams/test_app_streams.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams.py
@@ -472,7 +472,7 @@ async def test_systems_by_app_stream_no_primary_package_module():
 
 @pytest.mark.asyncio
 async def test_systems_by_app_stream_module_detected_via_unique_subpackages_without_meta_package():
-    """Regression test (RHINENG-9999): module detected via sub-packages installed by
+    """Regression test (RHINENG-29220): module detected via sub-packages installed by
     `dnf module install`, even when the module's own meta-package is absent.
 
     PHP's default profile (installed by `sudo dnf module install php:8.2`) installs
@@ -536,7 +536,7 @@ async def test_systems_by_app_stream_module_detected_via_unique_subpackages_with
 
 
 def test_shared_package_names_scoped_per_os_major():
-    """Regression test (RHINENG-9999 follow-up): package-name collisions across
+    """Regression test (RHINENG-29220 follow-up): package-name collisions across
     different RHEL major versions must NOT be treated as ambiguous.
 
     A single host only ever reports dnf_modules/packages for its own RHEL major
@@ -571,7 +571,7 @@ def test_shared_package_names_scoped_per_os_major():
 
 
 def test_shared_package_names_real_data_perl_dbd_mysql_not_ambiguous_on_rhel8():
-    """Regression test (RHINENG-9999 follow-up) against the real MODULE_PACKAGES data.
+    """Regression test (RHINENG-29220 follow-up) against the real MODULE_PACKAGES data.
 
     perl-DBD-MySQL is its own module on RHEL 8 (single-package: {"perl-DBD-MySQL"})
     and is also bundled as a sub-package of the "mysql" module on RHEL 9. These must

--- a/tests/v1/lifecycle/app_streams/test_app_streams.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams.py
@@ -468,3 +468,119 @@ async def test_systems_by_app_stream_no_primary_package_module():
         f"container-tools should be detected (enabled, no primary package, "
         f"but podman/buildah installed). Got: {module_names}"
     )
+
+
+@pytest.mark.asyncio
+async def test_systems_by_app_stream_module_detected_via_unique_subpackages_without_meta_package():
+    """Regression test (RHINENG-9999): module detected via sub-packages installed by
+    `dnf module install`, even when the module's own meta-package is absent.
+
+    PHP's default profile (installed by `sudo dnf module install php:8.2`) installs
+    php-cli, php-common, php-fpm, php-mbstring, php-xml, etc., but not the base
+    `php` meta-package itself. Since none of PHP's sub-packages are shared with any
+    other module, they are trustworthy evidence on their own and the module must
+    still be detected, even though the primary `php` package is missing and the
+    module's status includes "installed" alongside "enabled" (as `dnf module
+    install` produces).
+    """
+    systems_data = [
+        {
+            "id": "55555555-5555-5555-5555-555555555555",
+            "display_name": "test-php-no-meta-package",
+            "os_major": 8,
+            "os_minor": 10,
+            "dnf_modules": [
+                {"name": "php", "status": ["enabled", "installed"], "stream": "8.2"},
+            ],
+            "packages": [
+                "php-cli-8.2.31-1.module+el8.10.0+24323+abc2b0db.x86_64",
+                "php-common-8.2.31-1.module+el8.10.0+24323+abc2b0db.x86_64",
+                "php-fpm-8.2.31-1.module+el8.10.0+24323+abc2b0db.x86_64",
+                "php-mbstring-8.2.31-1.module+el8.10.0+24323+abc2b0db.x86_64",
+                "php-xml-8.2.31-1.module+el8.10.0+24323+abc2b0db.x86_64",
+                "bash-4.4.20-1.el8.x86_64",
+            ],
+        },
+    ]
+
+    class MockAsyncMappingsIterator:
+        def __init__(self, data):
+            self.data = data
+
+        def mappings(self):
+            return self
+
+        async def __aiter__(self):
+            for system in self.data:
+                yield system
+
+    class MockAsyncResult:
+        def __init__(self, data):
+            self.data = data
+
+        def yield_per(self, batch_size):
+            return MockAsyncMappingsIterator(self.data)
+
+        def mappings(self):
+            return self
+
+    mock_systems = MockAsyncResult(systems_data)
+    result = await systems_by_app_stream("test-org", mock_systems)
+    module_names = {key.name for key in result.keys()}
+
+    assert "php" in module_names, (
+        f"php should be detected (enabled+installed, meta-package 'php' absent, but "
+        f"unique sub-packages php-cli/php-common/php-fpm/php-mbstring/php-xml installed). "
+        f"Got: {module_names}"
+    )
+
+
+def test_shared_package_names_scoped_per_os_major():
+    """Regression test (RHINENG-9999 follow-up): package-name collisions across
+    different RHEL major versions must NOT be treated as ambiguous.
+
+    A single host only ever reports dnf_modules/packages for its own RHEL major
+    version, so two modules on *different* os_major values can never actually
+    collide for the same system — e.g. perl-DBD-MySQL is its own module on RHEL 8
+    but also a bundled sub-package of mysql on RHEL 9 in the real MODULE_PACKAGES
+    data. Computing shared-ness globally (ignoring os_major) would incorrectly
+    flag such packages as ambiguous, which is overly conservative and risks the
+    same silent-exclusion bug this ticket fixes, for unrelated modules on
+    unrelated RHEL versions.
+    """
+    from roadmap.data import _shared_package_names
+
+    fake_module_packages = {
+        # RHEL 8: "widget" and "gadget" genuinely share "shared-lib" -> ambiguous on RHEL 8.
+        ("widget", 8, "1.0"): {"widget-core", "shared-lib"},
+        ("gadget", 8, "2.0"): {"gadget-core", "shared-lib"},
+        # RHEL 9: "gizmo" happens to reuse the package name "widget-core" from the
+        # RHEL 8 "widget" module above. This must NOT make "widget-core" ambiguous
+        # on RHEL 8, since RHEL 8 and RHEL 9 module data never coexist on one host.
+        ("gizmo", 9, "1.0"): {"widget-core", "gizmo-core"},
+    }
+
+    result = _shared_package_names(fake_module_packages)
+
+    assert result[8] == {"shared-lib"}, f"Expected only 'shared-lib' ambiguous on RHEL 8. Got: {result.get(8)}"
+    assert "widget-core" not in result[8], (
+        "widget-core must not be ambiguous on RHEL 8 just because RHEL 9's unrelated "
+        "'gizmo' module happens to reuse the same package name."
+    )
+    assert result[9] == set(), f"No package is shared by two modules within RHEL 9 itself. Got: {result.get(9)}"
+
+
+def test_shared_package_names_real_data_perl_dbd_mysql_not_ambiguous_on_rhel8():
+    """Regression test (RHINENG-9999 follow-up) against the real MODULE_PACKAGES data.
+
+    perl-DBD-MySQL is its own module on RHEL 8 (single-package: {"perl-DBD-MySQL"})
+    and is also bundled as a sub-package of the "mysql" module on RHEL 9. These must
+    not be treated as ambiguous with each other, since they are on different RHEL
+    major versions and can never coexist on the same host.
+    """
+    from roadmap.data import SHARED_PACKAGE_NAMES_BY_OS_MAJOR
+
+    assert "perl-DBD-MySQL" not in SHARED_PACKAGE_NAMES_BY_OS_MAJOR.get(8, set()), (
+        "perl-DBD-MySQL must not be ambiguous on RHEL 8 merely because RHEL 9's "
+        "unrelated 'mysql' module happens to bundle a package of the same name."
+    )


### PR DESCRIPTION
RHINENG-29220

## Summary

PHP 8.2 (and any App Stream module whose `MODULE_PACKAGES` entry includes a package literally named the same as the module) stopped appearing on the Lifecycle → App Streams view when installed via the standard `sudo dnf module install php:8.2` command. That command installs the module's default profile (`php-cli`, `php-common`, `php-fpm`, `php-mbstring`, `php-xml`, etc.) but not the bare `php` meta-package, since it isn't part of the default profile.

This is a regression from `e28cc10` (#379), which required a module's "primary" package (same name as the module) to be installed whenever `MODULE_PACKAGES` contains one — even when other module-specific sub-packages were present. That rule was intended to prevent false positives from *genuinely shared* packages (e.g. `jansi`/`hawtjni-runtime`, which appear in both `scala` and `maven`), but it was applied too broadly and penalized any module with a same-named package, regardless of whether that package was actually ambiguous.

## Fix

Replaced the blanket "primary package required" rule with an ambiguity-aware one in `_verify_pending_modules()`:

- Only require the primary/module-name package when **every** matched installed package is ambiguous (i.e. also referenced by at least one *other* module on the same RHEL major version).
- Packages unique to a single module (within that RHEL major version) are trusted as evidence on their own.

Ambiguity is computed **per RHEL major version**, not globally — a package name that only collides with an unrelated module on a *different* major version (e.g. `perl-DBD-MySQL` is its own module on RHEL 8 but also a bundled sub-package of `mysql` on RHEL 9) can never actually collide on a real host, since a single host only ever reports one RHEL major version's modules.

The derived `_shared_package_names()` / `SHARED_PACKAGE_NAMES_BY_OS_MAJOR` helper was placed in `roadmap/data/__init__.py`, matching that module's existing pattern for precomputed derived data structures (`OS_MAJORS_BY_APP_NAME`, `APP_STREAM_MODULES_PACKAGES`, `APP_STREAMS`).

## Changes

- `src/roadmap/data/__init__.py` — added `_shared_package_names()` and `SHARED_PACKAGE_NAMES_BY_OS_MAJOR`
- `src/roadmap/v1/lifecycle/app_streams.py` — rewrote `_verify_pending_modules()` to use ambiguity-aware, os_major-scoped matching
- `tests/v1/lifecycle/app_streams/test_app_streams.py` — added 3 new unit tests:
  - `test_systems_by_app_stream_module_detected_via_unique_subpackages_without_meta_package` — reproduces the reported PHP 8.2 scenario
  - `test_shared_package_names_scoped_per_os_major` — proves cross-os_major collisions aren't falsely flagged as ambiguous
  - `test_shared_package_names_real_data_perl_dbd_mysql_not_ambiguous_on_rhel8` — asserts the real data's `perl-DBD-MySQL`/`mysql` collision isn't ambiguous on RHEL 8