### PR TITLE
Improve memory ussage

### DIFF
--- a/deploy/config.yml
+++ b/deploy/config.yml
@@ -340,7 +340,7 @@ parameters:
     value: 8192Mi
 
   - name: MEMORY_REQUEST_SERVICE
-    value: 4096Mi1
+    value: 4096Mi
 
   - name: CPU_LIMIT_SERVICE
     value: "2"

--- a/deploy/config.yml
+++ b/deploy/config.yml
@@ -337,10 +337,10 @@ parameters:
     value: "8000"
 
   - name: MEMORY_LIMIT_SERVICE
-    value: 2048Mi
+    value: 8192Mi
 
   - name: MEMORY_REQUEST_SERVICE
-    value: 1024Mi
+    value: 4096Mi1
 
   - name: CPU_LIMIT_SERVICE
     value: "2"

--- a/src/notificator/cache.py
+++ b/src/notificator/cache.py
@@ -1,0 +1,33 @@
+"""Cache management for the notificator.
+
+The NEVRA parser and app-stream package lookup use ``@functools.cache``
+(unbounded) to speed up repeated lookups within a single org.  When the
+notificator processes many orgs sequentially, those caches grow
+monotonically and can consume hundreds of megabytes of memory.
+
+Calling ``clear_caches()`` between orgs bounds memory to the size of the
+single largest org while keeping the within-org caching benefit intact.
+"""
+
+import structlog
+
+from roadmap.v1.lifecycle.app_streams import app_stream_from_package
+from roadmap.v1.lifecycle.app_streams import NEVRA
+
+
+logger = structlog.get_logger(__name__)
+
+
+def clear_caches() -> None:
+    """Clear NEVRA and app-stream package caches to reclaim memory."""
+    nevra_info = NEVRA.from_string.cache_info()
+    app_stream_info = app_stream_from_package.cache_info()
+
+    NEVRA.from_string.cache_clear()
+    app_stream_from_package.cache_clear()
+
+    logger.debug(
+        "Cleared inter-org caches",
+        nevra_cache_size=nevra_info.currsize,
+        app_stream_cache_size=app_stream_info.currsize,
+    )

--- a/src/notificator/lifecycle.py
+++ b/src/notificator/lifecycle.py
@@ -2,6 +2,7 @@ import time
 
 import structlog
 
+from notificator.cache import clear_caches
 from notificator.kafka import kafka_producer
 from notificator.notificator import Notificator
 from notificator.notificator_config import LIFECYCLE_SUBSCRIPTION
@@ -52,6 +53,8 @@ async def lifecycle_notification(
                         "Failed to process lifecycle notification", org_id=org_id, duration_seconds=round(elapsed, 2)
                     )
                     failed_orgs.append(org_id)
+                finally:
+                    clear_caches()
     except Exception:
         logger.exception("Failed to initialize Kafka producer for lifecycle notification, no orgs were notified.")
         return

--- a/src/notificator/roadmap.py
+++ b/src/notificator/roadmap.py
@@ -2,6 +2,7 @@ import time
 
 import structlog
 
+from notificator.cache import clear_caches
 from notificator.kafka import kafka_producer
 from notificator.notificator import Notificator
 from notificator.notificator_config import ROADMAP_SUBSCRIPTION
@@ -52,6 +53,8 @@ async def roadmap_notification(
                         "Failed to process roadmap notification", org_id=org_id, duration_seconds=round(elapsed, 2)
                     )
                     failed_orgs.append(org_id)
+                finally:
+                    clear_caches()
     except Exception:
         logger.exception("Failed to get kafka producer for roadmap notification, no orgs were notified.")
         return

--- a/tests/notificator/test_cache.py
+++ b/tests/notificator/test_cache.py
@@ -1,0 +1,142 @@
+"""Tests for notificator.cache — inter-org cache management."""
+
+from __future__ import annotations
+
+import pytest
+
+from notificator.cache import clear_caches
+from roadmap.v1.lifecycle.app_streams import app_stream_from_package
+from roadmap.v1.lifecycle.app_streams import NEVRA
+
+
+SAMPLE_NEVRAS = [
+    "glibc-0:2.34-168.el9_6.14.x86_64",
+    "bash-0:5.1.8-9.el9.x86_64",
+    "python3-libs-0:3.9.21-1.el9.x86_64",
+]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_caches():
+    """Ensure each test starts and ends with clean caches."""
+    NEVRA.from_string.cache_clear()
+    app_stream_from_package.cache_clear()
+    yield
+    NEVRA.from_string.cache_clear()
+    app_stream_from_package.cache_clear()
+
+
+class TestClearCaches:
+    """clear_caches(): both caches are emptied and their prior sizes are logged."""
+
+    def test_clears_nevra_cache(self):
+        """Populated NEVRA cache is emptied after clear_caches()."""
+        for nevra in SAMPLE_NEVRAS:
+            NEVRA.from_string(nevra)
+
+        assert NEVRA.from_string.cache_info().currsize == len(SAMPLE_NEVRAS)
+
+        clear_caches()
+
+        assert NEVRA.from_string.cache_info().currsize == 0
+
+    def test_clears_app_stream_from_package_cache(self):
+        """Populated app_stream_from_package cache is emptied after clear_caches()."""
+        for nevra in SAMPLE_NEVRAS:
+            app_stream_from_package(nevra, 9)
+
+        assert app_stream_from_package.cache_info().currsize == len(SAMPLE_NEVRAS)
+
+        clear_caches()
+
+        assert app_stream_from_package.cache_info().currsize == 0
+
+    def test_clears_both_caches_simultaneously(self):
+        """A single clear_caches() call empties both caches, not just one."""
+        NEVRA.from_string(SAMPLE_NEVRAS[0])
+        app_stream_from_package(SAMPLE_NEVRAS[0], 9)
+
+        assert NEVRA.from_string.cache_info().currsize == 1
+        assert app_stream_from_package.cache_info().currsize == 1
+
+        clear_caches()
+
+        assert NEVRA.from_string.cache_info().currsize == 0
+        assert app_stream_from_package.cache_info().currsize == 0
+
+    def test_noop_on_empty_caches(self):
+        """Calling clear_caches() on already-empty caches does not raise."""
+        assert NEVRA.from_string.cache_info().currsize == 0
+        assert app_stream_from_package.cache_info().currsize == 0
+
+        clear_caches()
+
+        assert NEVRA.from_string.cache_info().currsize == 0
+        assert app_stream_from_package.cache_info().currsize == 0
+
+    def test_caches_repopulate_after_clear(self):
+        """After clearing, new calls populate fresh cache entries (cache still works)."""
+        nevra_str = SAMPLE_NEVRAS[0]
+        NEVRA.from_string(nevra_str)
+        clear_caches()
+
+        assert NEVRA.from_string.cache_info().currsize == 0
+
+        result_a = NEVRA.from_string(nevra_str)
+        result_b = NEVRA.from_string(nevra_str)
+
+        assert NEVRA.from_string.cache_info().currsize == 1
+        assert NEVRA.from_string.cache_info().hits >= 1
+        assert result_a is result_b
+
+    def test_logs_cache_sizes_before_clear(self, mocker):
+        """The debug log message reports the cache sizes that existed *before* clearing."""
+        log_debug = mocker.patch("notificator.cache.logger.debug")
+
+        for nevra in SAMPLE_NEVRAS:
+            NEVRA.from_string(nevra)
+        app_stream_from_package(SAMPLE_NEVRAS[0], 8)
+        app_stream_from_package(SAMPLE_NEVRAS[0], 9)
+
+        clear_caches()
+
+        log_debug.assert_called_once_with(
+            "Cleared inter-org caches",
+            nevra_cache_size=len(SAMPLE_NEVRAS),
+            app_stream_cache_size=2,
+        )
+
+    def test_multiple_clears_in_sequence(self):
+        """Simulates the notificator loop: populate → clear → populate → clear."""
+        org1_nevras = SAMPLE_NEVRAS[:2]
+        org2_nevras = SAMPLE_NEVRAS[1:]
+
+        for nevra in org1_nevras:
+            NEVRA.from_string(nevra)
+            app_stream_from_package(nevra, 9)
+        assert NEVRA.from_string.cache_info().currsize == 2
+        assert app_stream_from_package.cache_info().currsize == 2
+
+        clear_caches()
+        assert NEVRA.from_string.cache_info().currsize == 0
+
+        for nevra in org2_nevras:
+            NEVRA.from_string(nevra)
+            app_stream_from_package(nevra, 9)
+        assert NEVRA.from_string.cache_info().currsize == 2
+        assert app_stream_from_package.cache_info().currsize == 2
+
+        clear_caches()
+        assert NEVRA.from_string.cache_info().currsize == 0
+        assert app_stream_from_package.cache_info().currsize == 0
+
+    def test_nevra_identity_lost_after_clear(self):
+        """After clearing, the same NEVRA string produces an equal but distinct object."""
+        nevra_str = SAMPLE_NEVRAS[0]
+        before = NEVRA.from_string(nevra_str)
+
+        clear_caches()
+
+        after = NEVRA.from_string(nevra_str)
+        assert before == after
+        assert before is not after


### PR DESCRIPTION
Increase memory for API so notificator can be tested. This configuration
should be later used for notification cronjob and for API reverted to
original values.

Testing cronjob is complicated, admin API endpoint to trigger it is
used.

Clear NEVRA/app-stream caches between orgs in notificator

Both caches use @functools.cache (unbounded). When processing
~200 orgs sequentially they grow monotonically, adding ~400-700
MB that is never reclaimed. Clearing after each org bounds
memory to the single largest org. API paths are not affected.