### PR TITLE
Update config and yield early

### DIFF
--- a/deploy/config.yml
+++ b/deploy/config.yml
@@ -115,7 +115,8 @@ objects:
                 path: /api/roadmap/v1/ping
                 port: ${{WEB_PORT}}
               initialDelaySeconds: 15
-              periodSeconds: 10
+              periodSeconds: 15
+              timeoutSeconds: 10
               failureThreshold: 6
 
             readinessProbe:
@@ -123,7 +124,8 @@ objects:
                 path: /api/roadmap/v1/ping
                 port: ${{WEB_PORT}}
               initialDelaySeconds: 15
-              periodSeconds: 10
+              periodSeconds: 15
+              timeoutSeconds: 10
               failureThreshold: 6
 
             volumeMounts:
@@ -337,10 +339,10 @@ parameters:
     value: "8000"
 
   - name: MEMORY_LIMIT_SERVICE
-    value: 32768Mi
+    value: 4096Mi
 
   - name: MEMORY_REQUEST_SERVICE
-    value: 4096Mi
+    value: 2048Mi
 
   - name: CPU_LIMIT_SERVICE
     value: "2"
@@ -406,10 +408,10 @@ parameters:
     value: 750m
 
   - name: MEMORY_REQUEST_NOTIFICATOR
-    value: 1024Mi
+    value: 2048Mi
 
   - name: MEMORY_LIMIT_NOTIFICATOR
-    value: 2048Mi
+    value: 4096Mi
 
   - name: LOG_LEVEL
     value: DEBUG

--- a/src/notificator/notificator.py
+++ b/src/notificator/notificator.py
@@ -233,7 +233,7 @@ class Notificator:
             ):
                 async for system in result.yield_per(2_000).mappings():
                     system_count += 1
-                    if system_count % 2_000 == 0:
+                    if system_count % 1_000 == 0:
                         logger.info("Processed systems for upcoming changes", org_id=self.org_id, count=system_count)
                         await asyncio.sleep(0)
 

--- a/tests/notificator/test_notificator.py
+++ b/tests/notificator/test_notificator.py
@@ -728,9 +728,9 @@ class TestGetRelevantUpcoming:
 
         assert result == Counter({"addition": 1})
 
-    async def test_cooperative_yield_fires_every_2000_hosts(self, notificator, mocker):
+    async def test_cooperative_yield_fires_every_1000_hosts(self, notificator, mocker):
         """Verify asyncio.sleep(0) is called to yield control back to the event loop."""
-        hosts = [make_host_mapping(i, os_major=9) for i in range(1, 2_002)]
+        hosts = [make_host_mapping(i, os_major=9) for i in range(1, 2_001)]
         self._set_matching_scenario(
             [make_upcoming_input("addition", date(2026, 4, 10))],
             hosts=hosts,
@@ -739,7 +739,8 @@ class TestGetRelevantUpcoming:
 
         await notificator.get_relevant_upcoming()
 
-        mock_sleep.assert_called_once_with(0)
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(0)
 
     async def test_deployed_date_none_uses_today(self, notificator):
         """Items with deployedDate=None use today's date and pass the window check."""


### PR DESCRIPTION
Current config with yield and allowing processing other requests like readinessProbe ad livenessProbe wasn't enough as processing 2000k hosts takes around 13 secs.

Decreasing the amount of hosts to be processed before yield and setting timeout to have some headroom.

Updating the memory allocation to current requirements - memory consumption is much lower now with streaming.