### PR TITLE
[RHINENG-29167] Add TTL caching for relevant lifecycle endpoints

### DIFF
--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -299,6 +299,28 @@ async def query_host_inventory(
         raise HTTPException(status_code=500, detail="Error querying host inventory")
 
 
+async def load_host_inventory_rows(
+    org_id: str,
+    session: AsyncSession,
+    settings: Settings,
+    host_groups: set[str | None],
+    major: int | None = None,
+    minor: int | None = None,
+) -> list[RowMapping]:
+    """Load host inventory rows into memory for endpoint-level processing/caching."""
+    async for result in query_host_inventory(
+        org_id=org_id,
+        session=session,
+        settings=settings,
+        host_groups=host_groups,
+        major=major,
+        minor=minor,
+    ):
+        return [row async for row in result.mappings()]
+
+    return []
+
+
 def get_lifecycle_type(products: list[dict[str, str]]) -> LifecycleType:
     """Calculate lifecycle type based on the product ID.
 

--- a/src/roadmap/config.py
+++ b/src/roadmap/config.py
@@ -34,6 +34,8 @@ class Settings(BaseSettings):
     env_name: str = "stage"
     log_level: str = "info"
     json_logging: bool = False
+    relevant_cache_ttl_seconds: int = 60
+    relevant_cache_maxsize: int = 512
 
     @property
     def database_url(self) -> PostgresDsn:

--- a/src/roadmap/services/relevant_cache.py
+++ b/src/roadmap/services/relevant_cache.py
@@ -1,0 +1,99 @@
+import copy
+import threading
+import time
+import typing as t
+
+
+class RelevantResponseCache:
+    """Simple in-memory TTL cache for relevant endpoint responses."""
+
+    def __init__(self):
+        self._entries: dict[tuple[t.Any, ...], tuple[float, t.Any]] = {}
+        self._lock = threading.Lock()
+
+    def get(self, key: tuple[t.Any, ...]) -> t.Any | None:
+        now = time.monotonic()
+        with self._lock:
+            item = self._entries.get(key)
+            if item is None:
+                return None
+
+            expires_at, value = item
+            if now >= expires_at:
+                self._entries.pop(key, None)
+                return None
+
+            # Never return shared mutable references.
+            return copy.deepcopy(value)
+
+    def set(self, key: tuple[t.Any, ...], value: t.Any, ttl_seconds: int, maxsize: int):
+        now = time.monotonic()
+        with self._lock:
+            if len(self._entries) >= maxsize:
+                # Remove expired entries first, then oldest expiry if still full.
+                expired = [k for k, (expires_at, _v) in self._entries.items() if now >= expires_at]
+                for expired_key in expired:
+                    self._entries.pop(expired_key, None)
+
+                if len(self._entries) >= maxsize and self._entries:
+                    oldest_key = min(self._entries.items(), key=lambda item: item[1][0])[0]
+                    self._entries.pop(oldest_key, None)
+
+            self._entries[key] = (now + ttl_seconds, copy.deepcopy(value))
+
+
+def normalize_host_groups(host_groups: set[str | None] | None) -> tuple[str, ...]:
+    """Return stable host-group key parts for cache scoping."""
+    if not host_groups:
+        return ()
+
+    normalized = []
+    for group_id in host_groups:
+        normalized.append("__ungrouped__" if group_id is None else group_id)
+    return tuple(sorted(normalized))
+
+
+def build_relevant_cache_key(
+    endpoint: str,
+    org_id: str,
+    related: bool,
+    host_groups: set[str | None] | None,
+    major: int | None = None,
+    minor: int | None = None,
+) -> tuple[t.Any, ...] | None:
+    """Build cache key with tenant and permission scoping."""
+    if not org_id:
+        # Never cache identity-less responses to avoid accidental cross-user reuse.
+        return None
+
+    return (
+        endpoint,
+        org_id,
+        related,
+        major,
+        minor,
+        normalize_host_groups(host_groups),
+    )
+
+
+relevant_response_cache = RelevantResponseCache()
+
+
+class CachedResult:
+    """Wrap row mappings with AsyncResult-like iteration helpers."""
+
+    def __init__(self, rows: list[t.Any]):
+        self._rows = rows
+
+    def yield_per(self, _n: int):
+        return self
+
+    def mappings(self):
+        return self
+
+    def __aiter__(self):
+        return self._async_iter()
+
+    async def _async_iter(self):
+        for row in self._rows:
+            yield row

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -17,14 +17,17 @@ from pydantic import AfterValidator
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import model_validator
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.asyncio.result import AsyncResult
 
 from roadmap.common import decode_header
 from roadmap.common import ensure_date
-from roadmap.common import query_host_inventory
+from roadmap.common import get_allowed_host_groups
+from roadmap.common import load_host_inventory_rows
 from roadmap.common import rhel_major_minor
 from roadmap.common import sort_attrs
 from roadmap.common import streams_lt
+from roadmap.config import Settings
 from roadmap.data import APP_STREAM_MODULES
 from roadmap.data import APP_STREAM_MODULES_BY_KEY
 from roadmap.data import APP_STREAM_MODULES_PACKAGES
@@ -37,11 +40,15 @@ from roadmap.data.app_streams import AppStreamEntity
 from roadmap.data.app_streams import AppStreamImplementation
 from roadmap.data.app_streams import AppStreamType
 from roadmap.data.systems import OS_LIFECYCLE_DATES
+from roadmap.database import get_db
 from roadmap.models import _calculate_support_status
 from roadmap.models import _get_system_uuids
 from roadmap.models import Meta
 from roadmap.models import SupportStatus
 from roadmap.models import SystemInfo
+from roadmap.services.relevant_cache import build_relevant_cache_key
+from roadmap.services.relevant_cache import CachedResult
+from roadmap.services.relevant_cache import relevant_response_cache
 
 
 logger = logging.getLogger("uvicorn.error")
@@ -373,8 +380,8 @@ def _verify_pending_modules(
 
 
 async def systems_by_app_stream(
-    org_id: t.Annotated[str, Depends(decode_header)],
-    systems: t.Annotated[AsyncResult, Depends(query_host_inventory)],
+    org_id: str,
+    systems: AsyncResult | CachedResult,
 ) -> dict[AppStreamKey, set[SystemInfo]]:
     """Return a mapping of AppStreams to informations about systems using that stream."""
     logger.info(f"Getting relevant app streams for {org_id or 'UNKNOWN'}")
@@ -662,9 +669,36 @@ relevant = APIRouter(
     response_model=RelevantAppStreamsResponse,
 )
 async def get_relevant_app_streams(
-    systems_by_stream: t.Annotated[dict[AppStreamKey, set[SystemInfo]], Depends(systems_by_app_stream)],
+    org_id: t.Annotated[str, Depends(decode_header)],
     related: bool = False,
+    settings: t.Annotated[Settings | None, Depends(Settings.create)] = None,
+    session: t.Annotated[AsyncSession | None, Depends(get_db)] = None,
+    host_groups: t.Annotated[set[str | None] | None, Depends(get_allowed_host_groups)] = None,
 ):
+    cache_key = build_relevant_cache_key(
+        endpoint="relevant-lifecycle-app-streams",
+        org_id=org_id,
+        related=related,
+        host_groups=host_groups,
+    )
+    if cache_key is not None:
+        if cached := relevant_response_cache.get(cache_key):
+            logger.debug("Relevant lifecycle app-streams response cache hit")
+            return cached
+
+    if session is None or settings is None:
+        raise RuntimeError("Missing database session for app stream lifecycle lookup")
+    rows = await load_host_inventory_rows(
+        org_id=org_id,
+        session=session,
+        settings=settings,
+        host_groups=host_groups or set(),
+    )
+    systems_by_stream = await systems_by_app_stream(
+        org_id=org_id,
+        systems=CachedResult(rows),
+    )
+
     relevant_app_streams = []
     for app_stream, systems in systems_by_stream.items():
         # Omit rolling app streams.
@@ -717,10 +751,18 @@ async def get_relevant_app_streams(
             except Exception as exc:
                 raise HTTPException(detail=str(exc), status_code=400)
 
-    return {
+    response = {
         "meta": {
             "count": len(relevant_app_streams),
             "total": sum(item.count for item in relevant_app_streams),
         },
         "data": sorted(relevant_app_streams, key=sort_attrs("name", "os_major", "os_minor")),
     }
+    if settings is not None and cache_key is not None:
+        relevant_response_cache.set(
+            cache_key,
+            response,
+            ttl_seconds=settings.relevant_cache_ttl_seconds,
+            maxsize=settings.relevant_cache_maxsize,
+        )
+    return response

--- a/src/roadmap/v1/lifecycle/rhel.py
+++ b/src/roadmap/v1/lifecycle/rhel.py
@@ -9,13 +9,17 @@ from fastapi import Depends
 from fastapi import Path
 from pydantic import BaseModel
 from pydantic import model_validator
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from roadmap.common import decode_header
+from roadmap.common import get_allowed_host_groups
 from roadmap.common import get_lifecycle_type
-from roadmap.common import query_host_inventory
+from roadmap.common import load_host_inventory_rows
 from roadmap.common import rhel_major_minor
 from roadmap.common import sort_attrs
+from roadmap.config import Settings
 from roadmap.data.systems import OS_LIFECYCLE_DATES
+from roadmap.database import get_db
 from roadmap.models import HostCount
 from roadmap.models import LifecycleType
 from roadmap.models import Meta
@@ -23,6 +27,9 @@ from roadmap.models import RHELLifecycle
 from roadmap.models import SupportStatus
 from roadmap.models import System
 from roadmap.models import SystemInfo
+from roadmap.services.relevant_cache import build_relevant_cache_key
+from roadmap.services.relevant_cache import CachedResult
+from roadmap.services.relevant_cache import relevant_response_cache
 
 
 logger = logging.getLogger("uvicorn.error")
@@ -143,9 +150,34 @@ relevant = APIRouter(
 )
 async def get_relevant_systems(  # noqa: C901
     org_id: t.Annotated[str, Depends(decode_header)],
-    systems: t.Annotated[t.Any, Depends(query_host_inventory)],
     related: bool = False,
+    systems: t.Any | None = None,
+    session: t.Annotated[AsyncSession | None, Depends(get_db)] = None,
+    settings: t.Annotated[Settings | None, Depends(Settings.create)] = None,
+    host_groups: t.Annotated[set[str | None] | None, Depends(get_allowed_host_groups)] = None,
 ) -> RelevantSystemsResponse:
+    cache_key = build_relevant_cache_key(
+        endpoint="relevant-lifecycle-rhel",
+        org_id=org_id,
+        related=related,
+        host_groups=host_groups,
+    )
+    if cache_key is not None:
+        if cached := relevant_response_cache.get(cache_key):
+            logger.debug("Relevant lifecycle rhel response cache hit")
+            return RelevantSystemsResponse.model_validate(cached)
+
+    if systems is None:
+        if session is None or settings is None:
+            raise RuntimeError("Missing database session for relevant lifecycle lookup")
+        rows = await load_host_inventory_rows(
+            org_id=org_id,
+            session=session,
+            settings=settings,
+            host_groups=host_groups or set(),
+        )
+        systems = CachedResult(rows)
+
     system_counts = defaultdict(int)
     missing = defaultdict(int)
     systems_by_version_lifecycle = defaultdict(set)
@@ -245,7 +277,15 @@ async def get_relevant_systems(  # noqa: C901
         missing_items = ", ".join(f"{key}: {value}" for key, value in missing.items())
         logger.info(f"Missing {missing_items} for org {org_id or 'UNKNOWN'}")
 
-    return RelevantSystemsResponse(
+    response = RelevantSystemsResponse(
         meta=Meta(total=sum(system.count for system in results), count=len(results)),
         data=sorted(results, key=sort_attrs("lifecycle_type", "major", "minor"), reverse=True),
     )
+    if settings is not None and cache_key is not None:
+        relevant_response_cache.set(
+            cache_key,
+            response.model_dump(mode="json"),
+            ttl_seconds=settings.relevant_cache_ttl_seconds,
+            maxsize=settings.relevant_cache_maxsize,
+        )
+    return response

--- a/tests/test_relevant_cache.py
+++ b/tests/test_relevant_cache.py
@@ -1,0 +1,55 @@
+from roadmap.services import relevant_cache as cache_module
+from roadmap.services.relevant_cache import build_relevant_cache_key
+from roadmap.services.relevant_cache import RelevantResponseCache
+
+
+def test_relevant_response_cache_hit_and_expiry(monkeypatch):
+    cache = RelevantResponseCache()
+    key = ("relevant-lifecycle-rhel", "1234", False, None, None)
+    timeline = iter([0.0, 0.5, 1.2])
+    monkeypatch.setattr(cache_module.time, "monotonic", lambda: next(timeline))
+
+    cache.set(key, {"data": [1]}, ttl_seconds=1, maxsize=8)
+    assert cache.get(key) == {"data": [1]}
+    assert cache.get(key) is None
+
+
+def test_relevant_response_cache_returns_deep_copy(monkeypatch):
+    cache = RelevantResponseCache()
+    key = ("relevant-lifecycle-app-streams", "1234", True, None, None)
+    monkeypatch.setattr(cache_module.time, "monotonic", lambda: 0.0)
+    cache.set(key, {"data": [{"name": "nodejs"}]}, ttl_seconds=10, maxsize=8)
+
+    cached = cache.get(key)
+    assert cached is not None
+    cached["data"][0]["name"] = "mutated"
+
+    again = cache.get(key)
+    assert again is not None
+    assert again["data"][0]["name"] == "nodejs"
+
+
+def test_build_relevant_cache_key_scopes_by_host_groups():
+    key_a = build_relevant_cache_key(
+        endpoint="relevant-lifecycle-rhel",
+        org_id="1234",
+        related=False,
+        host_groups={"group-a"},
+    )
+    key_b = build_relevant_cache_key(
+        endpoint="relevant-lifecycle-rhel",
+        org_id="1234",
+        related=False,
+        host_groups={"group-b"},
+    )
+    assert key_a != key_b
+
+
+def test_build_relevant_cache_key_skips_missing_org():
+    key = build_relevant_cache_key(
+        endpoint="relevant-lifecycle-rhel",
+        org_id="",
+        related=False,
+        host_groups={"group-a"},
+    )
+    assert key is None

--- a/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
@@ -6,11 +6,14 @@ from urllib.error import HTTPError
 import pytest
 
 from roadmap.common import decode_header
+from roadmap.common import get_allowed_host_groups
+from roadmap.common import get_db
 from roadmap.common import query_rbac
 from roadmap.config import Settings
 from roadmap.data.app_streams import AppStreamEntity
 from roadmap.data.app_streams import AppStreamType
 from roadmap.models import SupportStatus
+from roadmap.services import relevant_cache as cache_module
 from roadmap.v1.lifecycle.app_streams import AppStreamImplementation
 from roadmap.v1.lifecycle.app_streams import NEVRA
 from roadmap.v1.lifecycle.app_streams import RelevantAppStream
@@ -55,6 +58,69 @@ def test_get_relevant_app_stream(api_prefix, client):
     assert all([len(set(item["systems"])) == len(item["systems"]) for item in data]), (
         "Found duplicate system IDs in results"
     )
+
+
+def test_get_relevant_app_stream_response_cache_and_key_isolation(api_prefix, client, monkeypatch):
+    async def query_rbac_override():
+        return [{"permission": "inventory:*:*", "resourceDefinitions": []}]
+
+    async def decode_header_override():
+        return "1234"
+
+    async def get_allowed_host_groups_override():
+        return {"group-a"}
+
+    async def get_db_override():
+        yield object()
+
+    settings = Settings(dev=True, relevant_cache_ttl_seconds=1, relevant_cache_maxsize=32)
+    timeline = iter([0.0, 0.1, 0.2, 0.3, 1.5, 1.6, 1.7, 1.8, 1.9])
+    monkeypatch.setattr(cache_module.time, "monotonic", lambda: next(timeline))
+    monkeypatch.setattr(cache_module.relevant_response_cache, "_entries", {})
+
+    rows = [
+        {
+            "id": "02f7e6ea-a0f6-4a98-b857-b0e9f9f0f111",
+            "display_name": "cache-host",
+            "os_name": "RHEL",
+            "os_major": 9,
+            "os_minor": 2,
+            "os_release": "9.2",
+            "dnf_modules": [{"name": "nodejs", "stream": "18", "status": ["installed"]}],
+            "packages": ["nodejs-1:18.18.0-1.el9.x86_64"],
+            "products": [],
+        }
+    ]
+    load_calls = {"count": 0}
+
+    async def fake_load_host_inventory_rows(*args, **kwargs):
+        load_calls["count"] += 1
+        return rows
+
+    monkeypatch.setattr(
+        "roadmap.v1.lifecycle.app_streams.load_host_inventory_rows",
+        fake_load_host_inventory_rows,
+    )
+
+    client.app.dependency_overrides = {}
+    client.app.dependency_overrides[query_rbac] = query_rbac_override
+    client.app.dependency_overrides[decode_header] = decode_header_override
+    client.app.dependency_overrides[get_allowed_host_groups] = get_allowed_host_groups_override
+    client.app.dependency_overrides[get_db] = get_db_override
+    client.app.dependency_overrides[Settings.create] = lambda: settings
+
+    first = client.get(f"{api_prefix}/relevant/lifecycle/app-streams")
+    second = client.get(f"{api_prefix}/relevant/lifecycle/app-streams")
+    third = client.get(f"{api_prefix}/relevant/lifecycle/app-streams", params={"related": "true"})
+    fourth = client.get(f"{api_prefix}/relevant/lifecycle/app-streams", params={"related": "true"})
+    fifth = client.get(f"{api_prefix}/relevant/lifecycle/app-streams")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert third.status_code == 200
+    assert fourth.status_code == 200
+    assert fifth.status_code == 200
+    assert load_calls["count"] == 3, "Expected misses only for first, related=true key, and post-ttl request"
 
 
 def test_get_relevant_app_stream_error(api_prefix, client, mocker):

--- a/tests/v1/lifecycle/test_rhel.py
+++ b/tests/v1/lifecycle/test_rhel.py
@@ -3,9 +3,13 @@ import uuid
 import pytest
 
 from roadmap.common import decode_header
+from roadmap.common import get_allowed_host_groups
+from roadmap.common import get_db
 from roadmap.common import query_rbac
+from roadmap.config import Settings
 from roadmap.data.systems import OS_LIFECYCLE_DATES
 from roadmap.models import System
+from roadmap.services import relevant_cache as cache_module
 
 
 def test_rhel_lifecycle(client, api_prefix):
@@ -96,6 +100,65 @@ def test_rhel_relevant(client, api_prefix, ids_by_os):
     assert rhel_9_1_mainline == ids_by_os["9.1"]
     for item in data:
         assert item["count"] == len(item["systems"]), "Mismatch between count and number of system IDs"
+
+
+def test_rhel_relevant_response_cache_hit_and_ttl_expiry(client, api_prefix, monkeypatch):
+    async def query_rbac_override():
+        return [{"permission": "inventory:*:*", "resourceDefinitions": []}]
+
+    async def decode_header_override():
+        return "1234"
+
+    async def get_allowed_host_groups_override():
+        return {"group-a"}
+
+    async def get_db_override():
+        yield object()
+
+    settings = Settings(dev=True, relevant_cache_ttl_seconds=1, relevant_cache_maxsize=32)
+    timeline = iter([0.0, 0.1, 0.2, 1.5, 1.6])
+    monkeypatch.setattr(cache_module.time, "monotonic", lambda: next(timeline))
+    monkeypatch.setattr(cache_module.relevant_response_cache, "_entries", {})
+
+    rows = [
+        {
+            "id": "02f7e6ea-a0f6-4a98-b857-b0e9f9f0f111",
+            "display_name": "cache-host",
+            "os_name": "RHEL",
+            "os_major": 9,
+            "os_minor": 2,
+            "os_release": "9.2",
+            "dnf_modules": [],
+            "packages": [],
+            "products": [],
+        }
+    ]
+    load_calls = {"count": 0}
+
+    async def fake_load_host_inventory_rows(*args, **kwargs):
+        load_calls["count"] += 1
+        return rows
+
+    monkeypatch.setattr(
+        "roadmap.v1.lifecycle.rhel.load_host_inventory_rows",
+        fake_load_host_inventory_rows,
+    )
+
+    client.app.dependency_overrides = {}
+    client.app.dependency_overrides[query_rbac] = query_rbac_override
+    client.app.dependency_overrides[decode_header] = decode_header_override
+    client.app.dependency_overrides[get_allowed_host_groups] = get_allowed_host_groups_override
+    client.app.dependency_overrides[get_db] = get_db_override
+    client.app.dependency_overrides[Settings.create] = lambda: settings
+
+    first = client.get(f"{api_prefix}/relevant/lifecycle/rhel")
+    second = client.get(f"{api_prefix}/relevant/lifecycle/rhel")
+    third = client.get(f"{api_prefix}/relevant/lifecycle/rhel")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert third.status_code == 200
+    assert load_calls["count"] == 2, "Expected one cache hit between two misses"
 
 
 def test_rhel_relevant_extended_dates(client, api_prefix):


### PR DESCRIPTION
Reduce repeated host-inventory work by caching relevant lifecycle responses with TTL and permission-scoped keys, and add focused tests for hit/miss, expiry, and cache isolation behavior.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added response caching for relevant app-stream and RHEL lifecycle results.
  * Cached responses now respect configurable expiration times and capacity limits.
  * Cache entries are isolated by organization, permissions, host groups, filters, and related-result options.
* **Bug Fixes**
  * Improved inventory loading when no results are available.
  * Prevented stale cached responses from being returned after expiration.
* **Tests**
  * Added coverage for cache hits, expiration, isolation, and data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->