### PR TITLE
Fix RBAC 400 by skipping httpx default headers

### DIFF
--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -75,11 +75,12 @@ async def query_rbac(
 
     try:
         async with httpx.AsyncClient(timeout=30) as client:
-            response = await client.get(url, headers=headers)
+            request = httpx.Request("GET", url, headers=headers)
+            response = await client.send(request)
             response.raise_for_status()
             data = response.json()
     except httpx.HTTPStatusError as err:
-        logger.error(f"Problem querying RBAC: {err}")
+        logger.error(f"Problem querying RBAC: {err}, body={err.response.text}")
         raise HTTPException(status_code=err.response.status_code, detail=str(err))
     except (json.JSONDecodeError, ValueError) as err:
         logger.error(f"Invalid JSON response from RBAC: {err}")

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -160,7 +160,7 @@ async def test_query_rbac(mocker, read_fixture_file):
     mock_response.json.return_value = fixture_data
     mock_response.raise_for_status = MagicMock()
     mock_client = AsyncMock()
-    mock_client.get.return_value = mock_response
+    mock_client.send.return_value = mock_response
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)
@@ -178,7 +178,7 @@ async def test_query_rbac_error(mocker):
         "Raised intentionally", request=httpx.Request("GET", "http://example.com"), response=error_response
     )
     mock_client = AsyncMock()
-    mock_client.get.return_value = mock_response
+    mock_client.send.return_value = mock_response
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)
@@ -209,7 +209,7 @@ async def test_query_rbac_json_decode_error(mocker):
     mock_response.raise_for_status = MagicMock()
     mock_response.json.side_effect = ValueError("invalid json")
     mock_client = AsyncMock()
-    mock_client.get.return_value = mock_response
+    mock_client.send.return_value = mock_response
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)
@@ -221,7 +221,7 @@ async def test_query_rbac_json_decode_error(mocker):
 async def test_query_rbac_timeout(mocker):
     settings = Settings(rbac_hostname="example.com")
     mock_client = AsyncMock()
-    mock_client.get.side_effect = httpx.ReadTimeout("Timed out")
+    mock_client.send.side_effect = httpx.ReadTimeout("Timed out")
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)
@@ -235,7 +235,7 @@ async def test_query_rbac_timeout(mocker):
 async def test_query_rbac_generic_exception(mocker):
     settings = Settings(rbac_hostname="example.com")
     mock_client = AsyncMock()
-    mock_client.get.side_effect = Exception("Connection timeout")
+    mock_client.send.side_effect = Exception("Connection timeout")
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)

--- a/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
@@ -68,7 +68,7 @@ def test_get_relevant_app_stream_error(api_prefix, client, mocker):
     )
 
     mock_client = AsyncMock()
-    mock_client.get.return_value = mock_response
+    mock_client.send.return_value = mock_response
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)


### PR DESCRIPTION
Use httpx.Request + client.send() instead of client.get() to avoid injecting default accept/accept-encoding/connection/user-agent headers that the RBAC service rejects. Also log response body on HTTP errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RBAC request handling for more reliable error processing.
  * HTTP error logs now include response details, making failures easier to diagnose.
  * Improved error-path handling for application stream operations.

* **Tests**
  * Updated coverage for successful responses, HTTP errors, invalid JSON, timeouts, and unexpected exceptions.
  * Added verification for application stream error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->