### PR TITLE
Revert RBAC to urllib with asyncio.to_thread to fix stage 400

### DIFF
--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -52,7 +52,7 @@ async def decode_header(
 
 
 class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
-    def redirect_request(self, req, fp, code, _msg, headers, _newurl):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
         raise HTTPError(req.full_url, code, "RBAC redirect blocked", headers, fp)
 
 

--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -10,6 +10,7 @@ import urllib.request
 from collections.abc import AsyncGenerator
 from datetime import date
 from urllib.error import HTTPError
+from urllib.error import URLError
 from uuid import UUID
 
 from fastapi import Depends
@@ -90,6 +91,15 @@ async def query_rbac(
     except HTTPError as err:
         logger.error("Problem querying RBAC: status=%s %s", err.code, err)
         raise HTTPException(status_code=err.code, detail=err.msg)
+    except URLError as err:
+        if isinstance(err.reason, TimeoutError):
+            logger.error("Timeout querying RBAC: %s", err)
+            raise HTTPException(status_code=504, detail="RBAC service timed out")
+        logger.error(f"Unexpected error querying RBAC: {err}", exc_info=True)
+        raise HTTPException(status_code=502, detail="Error communicating with RBAC service")
+    except TimeoutError as err:
+        logger.error("Timeout querying RBAC: %s", err)
+        raise HTTPException(status_code=504, detail="RBAC service timed out")
     except json.JSONDecodeError as err:
         logger.error(f"Invalid JSON response from RBAC: {err}")
         raise HTTPException(status_code=502, detail="Invalid JSON response from RBAC service")

--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -1,15 +1,16 @@
+import asyncio
 import base64
 import json
 import logging
 import textwrap
 import typing as t
 import urllib.parse
+import urllib.request
 
 from collections.abc import AsyncGenerator
 from datetime import date
+from urllib.error import HTTPError
 from uuid import UUID
-
-import httpx
 
 from fastapi import Depends
 from fastapi import FastAPI
@@ -73,21 +74,19 @@ async def query_rbac(
 
     url = f"{settings.rbac_url}/api/rbac/v1/access/?{urllib.parse.urlencode(params, doseq=True)}"
 
+    def _fetch_rbac():
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req) as response:
+            return json.load(response)
+
     try:
-        async with httpx.AsyncClient(timeout=30) as client:
-            request = httpx.Request("GET", url, headers=headers)
-            response = await client.send(request)
-            response.raise_for_status()
-            data = response.json()
-    except httpx.HTTPStatusError as err:
-        logger.error(f"Problem querying RBAC: {err}, body={err.response.text}")
-        raise HTTPException(status_code=err.response.status_code, detail=str(err))
-    except (json.JSONDecodeError, ValueError) as err:
+        data = await asyncio.to_thread(_fetch_rbac)
+    except HTTPError as err:
+        logger.error("Problem querying RBAC: status=%s %s", err.code, err)
+        raise HTTPException(status_code=err.code, detail=err.msg)
+    except json.JSONDecodeError as err:
         logger.error(f"Invalid JSON response from RBAC: {err}")
         raise HTTPException(status_code=502, detail="Invalid JSON response from RBAC service")
-    except httpx.TimeoutException as err:
-        logger.error(f"Timeout querying RBAC: {err}")
-        raise HTTPException(status_code=504, detail="RBAC service timed out")
     except Exception as err:
         logger.error(f"Unexpected error querying RBAC: {err}", exc_info=True)
         raise HTTPException(status_code=502, detail="Error communicating with RBAC service")

--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -53,7 +53,7 @@ async def decode_header(
 
 
 class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
-    def redirect_request(self, req, fp, code, msg, headers, newurl):
+    def redirect_request(self, req, fp, code, msg, headers, newurl) -> t.NoReturn:
         raise HTTPError(req.full_url, code, "RBAC redirect blocked", headers, fp)
 
 

--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -51,6 +51,11 @@ async def decode_header(
     return org_id
 
 
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise HTTPError(req.full_url, code, f"Redirect to {newurl} blocked", headers, fp)
+
+
 async def query_rbac(
     settings: t.Annotated[Settings, Depends(Settings.create)],
     x_rh_identity: t.Annotated[str | None, Header(include_in_schema=False)] = None,
@@ -75,8 +80,9 @@ async def query_rbac(
     url = f"{settings.rbac_url}/api/rbac/v1/access/?{urllib.parse.urlencode(params, doseq=True)}"
 
     def _fetch_rbac():
+        opener = urllib.request.build_opener(_NoRedirectHandler)
         req = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(req) as response:
+        with opener.open(req, timeout=30) as response:
             return json.load(response)
 
     try:

--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -52,8 +52,8 @@ async def decode_header(
 
 
 class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
-    def redirect_request(self, req, fp, code, msg, headers, newurl):
-        raise HTTPError(req.full_url, code, f"Redirect to {newurl} blocked", headers, fp)
+    def redirect_request(self, req, fp, code, _msg, headers, _newurl):
+        raise HTTPError(req.full_url, code, "RBAC redirect blocked", headers, fp)
 
 
 async def query_rbac(

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -223,6 +223,33 @@ def test_query_rbac_redirect_blocked():
         handler.redirect_request(req, None, 302, "Found", {}, "http://evil.com/steal")
 
     assert exc_info.value.code == 302
+    assert exc_info.value.msg == "RBAC redirect blocked"
+
+
+async def test_query_rbac_socket_timeout(mocker):
+    from urllib.error import URLError
+
+    settings = Settings(rbac_hostname="example.com")
+    mock_opener = MagicMock()
+    mock_opener.open.side_effect = URLError(TimeoutError("timed out"))
+    mocker.patch("roadmap.common.urllib.request.build_opener", return_value=mock_opener)
+
+    with pytest.raises(HTTPException, match="RBAC service timed out") as exc_info:
+        await query_rbac(settings)
+
+    assert exc_info.value.status_code == 504
+
+
+async def test_query_rbac_direct_timeout(mocker):
+    settings = Settings(rbac_hostname="example.com")
+    mock_opener = MagicMock()
+    mock_opener.open.side_effect = TimeoutError("read timed out")
+    mocker.patch("roadmap.common.urllib.request.build_opener", return_value=mock_opener)
+
+    with pytest.raises(HTTPException, match="RBAC service timed out") as exc_info:
+        await query_rbac(settings)
+
+    assert exc_info.value.status_code == 504
 
 
 async def test_query_rbac_generic_exception(mocker):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -4,8 +4,9 @@ from contextlib import nullcontext
 from datetime import date
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
+from unittest.mock import patch
+from urllib.error import HTTPError
 
-import httpx
 import pytest
 
 from fastapi import HTTPException
@@ -156,14 +157,10 @@ async def test_decode_header(value, expected):
 async def test_query_rbac(mocker, read_fixture_file):
     settings = Settings(rbac_hostname="example.com")
     fixture_data = json.loads(read_fixture_file("rbac_response.json", mode="rb"))
-    mock_response = MagicMock()
-    mock_response.json.return_value = fixture_data
-    mock_response.raise_for_status = MagicMock()
-    mock_client = AsyncMock()
-    mock_client.send.return_value = mock_response
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-    mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)
+    mock_urlopen = MagicMock()
+    mock_urlopen.__enter__ = MagicMock(return_value=MagicMock(read=MagicMock(return_value=json.dumps(fixture_data).encode())))
+    mock_urlopen.__exit__ = MagicMock(return_value=False)
+    mocker.patch("roadmap.common.urllib.request.urlopen", return_value=mock_urlopen)
 
     result = await query_rbac(settings)
 
@@ -172,19 +169,15 @@ async def test_query_rbac(mocker, read_fixture_file):
 
 async def test_query_rbac_error(mocker):
     settings = Settings(rbac_hostname="example.com")
-    error_response = httpx.Response(401)
-    mock_response = MagicMock()
-    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
-        "Raised intentionally", request=httpx.Request("GET", "http://example.com"), response=error_response
+    mocker.patch(
+        "roadmap.common.urllib.request.urlopen",
+        side_effect=HTTPError("http://example.com", 401, "Unauthorized", {}, None),
     )
-    mock_client = AsyncMock()
-    mock_client.send.return_value = mock_response
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-    mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)
 
-    with pytest.raises(HTTPException, match="Raised intentionally"):
+    with pytest.raises(HTTPException) as exc_info:
         await query_rbac(settings)
+
+    assert exc_info.value.status_code == 401
 
 
 async def test_query_rbac_dev_mode():
@@ -205,40 +198,18 @@ async def test_query_rbac_no_url():
 
 async def test_query_rbac_json_decode_error(mocker):
     settings = Settings(rbac_hostname="example.com")
-    mock_response = MagicMock()
-    mock_response.raise_for_status = MagicMock()
-    mock_response.json.side_effect = ValueError("invalid json")
-    mock_client = AsyncMock()
-    mock_client.send.return_value = mock_response
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-    mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)
+    mock_urlopen = MagicMock()
+    mock_urlopen.__enter__ = MagicMock(return_value=MagicMock(read=MagicMock(return_value=b"not json")))
+    mock_urlopen.__exit__ = MagicMock(return_value=False)
+    mocker.patch("roadmap.common.urllib.request.urlopen", return_value=mock_urlopen)
 
     with pytest.raises(HTTPException, match="Invalid JSON response from RBAC service"):
         await query_rbac(settings)
 
 
-async def test_query_rbac_timeout(mocker):
-    settings = Settings(rbac_hostname="example.com")
-    mock_client = AsyncMock()
-    mock_client.send.side_effect = httpx.ReadTimeout("Timed out")
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-    mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)
-
-    with pytest.raises(HTTPException, match="RBAC service timed out") as exc_info:
-        await query_rbac(settings)
-
-    assert exc_info.value.status_code == 504
-
-
 async def test_query_rbac_generic_exception(mocker):
     settings = Settings(rbac_hostname="example.com")
-    mock_client = AsyncMock()
-    mock_client.send.side_effect = Exception("Connection timeout")
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-    mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)
+    mocker.patch("roadmap.common.urllib.request.urlopen", side_effect=Exception("Connection timeout"))
 
     with pytest.raises(HTTPException, match="Error communicating with RBAC service"):
         await query_rbac(settings)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -155,29 +155,32 @@ async def test_decode_header(value, expected):
 async def test_query_rbac(mocker, read_fixture_file):
     settings = Settings(rbac_hostname="example.com")
     fixture_data = json.loads(read_fixture_file("rbac_response.json", mode="rb"))
-    mock_urlopen = MagicMock()
-    mock_urlopen.__enter__ = MagicMock(
+    mock_response = MagicMock()
+    mock_response.__enter__ = MagicMock(
         return_value=MagicMock(read=MagicMock(return_value=json.dumps(fixture_data).encode()))
     )
-    mock_urlopen.__exit__ = MagicMock(return_value=False)
-    mocker.patch("roadmap.common.urllib.request.urlopen", return_value=mock_urlopen)
+    mock_response.__exit__ = MagicMock(return_value=False)
+    mock_opener = MagicMock()
+    mock_opener.open.return_value = mock_response
+    mocker.patch("roadmap.common.urllib.request.build_opener", return_value=mock_opener)
 
     result = await query_rbac(settings)
 
     assert result == [{"permission": "inventory:*:*:foo", "resourceDefinitions": []}]
+    assert mock_opener.open.call_args.kwargs["timeout"] == 30
 
 
 async def test_query_rbac_error(mocker):
     settings = Settings(rbac_hostname="example.com")
-    mocker.patch(
-        "roadmap.common.urllib.request.urlopen",
-        side_effect=HTTPError("http://example.com", 401, "Unauthorized", {}, None),
-    )
+    mock_opener = MagicMock()
+    mock_opener.open.side_effect = HTTPError("http://example.com", 401, "Unauthorized", {}, None)
+    mocker.patch("roadmap.common.urllib.request.build_opener", return_value=mock_opener)
 
     with pytest.raises(HTTPException) as exc_info:
         await query_rbac(settings)
 
     assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Unauthorized"
 
 
 async def test_query_rbac_dev_mode():
@@ -198,18 +201,35 @@ async def test_query_rbac_no_url():
 
 async def test_query_rbac_json_decode_error(mocker):
     settings = Settings(rbac_hostname="example.com")
-    mock_urlopen = MagicMock()
-    mock_urlopen.__enter__ = MagicMock(return_value=MagicMock(read=MagicMock(return_value=b"not json")))
-    mock_urlopen.__exit__ = MagicMock(return_value=False)
-    mocker.patch("roadmap.common.urllib.request.urlopen", return_value=mock_urlopen)
+    mock_response = MagicMock()
+    mock_response.__enter__ = MagicMock(return_value=MagicMock(read=MagicMock(return_value=b"not json")))
+    mock_response.__exit__ = MagicMock(return_value=False)
+    mock_opener = MagicMock()
+    mock_opener.open.return_value = mock_response
+    mocker.patch("roadmap.common.urllib.request.build_opener", return_value=mock_opener)
 
     with pytest.raises(HTTPException, match="Invalid JSON response from RBAC service"):
         await query_rbac(settings)
 
 
+def test_query_rbac_redirect_blocked():
+    from roadmap.common import _NoRedirectHandler
+
+    handler = _NoRedirectHandler()
+    req = MagicMock()
+    req.full_url = "http://rbac-service.svc:8000/api/rbac/v1/access/"
+
+    with pytest.raises(HTTPError) as exc_info:
+        handler.redirect_request(req, None, 302, "Found", {}, "http://evil.com/steal")
+
+    assert exc_info.value.code == 302
+
+
 async def test_query_rbac_generic_exception(mocker):
     settings = Settings(rbac_hostname="example.com")
-    mocker.patch("roadmap.common.urllib.request.urlopen", side_effect=Exception("Connection timeout"))
+    mock_opener = MagicMock()
+    mock_opener.open.side_effect = Exception("Connection timeout")
+    mocker.patch("roadmap.common.urllib.request.build_opener", return_value=mock_opener)
 
     with pytest.raises(HTTPException, match="Error communicating with RBAC service"):
         await query_rbac(settings)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,9 +2,7 @@ import json
 
 from contextlib import nullcontext
 from datetime import date
-from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
-from unittest.mock import patch
 from urllib.error import HTTPError
 
 import pytest
@@ -158,7 +156,9 @@ async def test_query_rbac(mocker, read_fixture_file):
     settings = Settings(rbac_hostname="example.com")
     fixture_data = json.loads(read_fixture_file("rbac_response.json", mode="rb"))
     mock_urlopen = MagicMock()
-    mock_urlopen.__enter__ = MagicMock(return_value=MagicMock(read=MagicMock(return_value=json.dumps(fixture_data).encode())))
+    mock_urlopen.__enter__ = MagicMock(
+        return_value=MagicMock(read=MagicMock(return_value=json.dumps(fixture_data).encode()))
+    )
     mock_urlopen.__exit__ = MagicMock(return_value=False)
     mocker.patch("roadmap.common.urllib.request.urlopen", return_value=mock_urlopen)
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -252,6 +252,20 @@ async def test_query_rbac_direct_timeout(mocker):
     assert exc_info.value.status_code == 504
 
 
+async def test_query_rbac_url_error(mocker):
+    from urllib.error import URLError
+
+    settings = Settings(rbac_hostname="example.com")
+    mock_opener = MagicMock()
+    mock_opener.open.side_effect = URLError("Name or service not known")
+    mocker.patch("roadmap.common.urllib.request.build_opener", return_value=mock_opener)
+
+    with pytest.raises(HTTPException, match="Error communicating with RBAC service") as exc_info:
+        await query_rbac(settings)
+
+    assert exc_info.value.status_code == 502
+
+
 async def test_query_rbac_generic_exception(mocker):
     settings = Settings(rbac_hostname="example.com")
     mock_opener = MagicMock()

--- a/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
@@ -59,10 +59,11 @@ def test_get_relevant_app_stream_error(api_prefix, client, mocker):
     def settings_override():
         return Settings(rbac_hostname="example.com")
 
-    mocker.patch(
-        "roadmap.common.urllib.request.urlopen",
-        side_effect=HTTPError("http://example.com", 400, "Bad Request", {}, None),
-    )
+    from unittest.mock import MagicMock
+
+    mock_opener = MagicMock()
+    mock_opener.open.side_effect = HTTPError("http://example.com", 400, "Bad Request", {}, None)
+    mocker.patch("roadmap.common.urllib.request.build_opener", return_value=mock_opener)
 
     client.app.dependency_overrides = {}
     client.app.dependency_overrides[Settings.create] = settings_override

--- a/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
@@ -1,6 +1,4 @@
 from datetime import date
-from unittest.mock import AsyncMock
-from unittest.mock import MagicMock
 from urllib.error import HTTPError
 
 import pytest

--- a/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
@@ -1,8 +1,8 @@
 from datetime import date
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
+from urllib.error import HTTPError
 
-import httpx
 import pytest
 
 from roadmap.common import decode_header
@@ -61,17 +61,10 @@ def test_get_relevant_app_stream_error(api_prefix, client, mocker):
     def settings_override():
         return Settings(rbac_hostname="example.com")
 
-    error_response = httpx.Response(400)
-    mock_response = MagicMock()
-    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
-        "Raised intentionally", request=httpx.Request("GET", "http://example.com"), response=error_response
+    mocker.patch(
+        "roadmap.common.urllib.request.urlopen",
+        side_effect=HTTPError("http://example.com", 400, "Bad Request", {}, None),
     )
-
-    mock_client = AsyncMock()
-    mock_client.send.return_value = mock_response
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-    mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)
 
     client.app.dependency_overrides = {}
     client.app.dependency_overrides[Settings.create] = settings_override


### PR DESCRIPTION
httpx caused 400 Bad Request from RBAC service on stage regardless of header configuration. Wrap the original urllib call in asyncio.to_thread to keep the event loop unblocked without changing HTTP wire behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of RBAC service HTTP errors by returning the relevant status code and message.
  * Preserved appropriate responses for invalid JSON and unexpected request failures.
  * Blocked unexpected redirects during RBAC requests.
  * Maintained the 30-second request timeout for consistent service response behavior.
  * Maintained correct error responses for application stream operations when the RBAC service returns an HTTP error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->