### PR TITLE
Properly sort image tags with longer version numbers

### DIFF
--- a/scripts/update-konflux-refs.py
+++ b/scripts/update-konflux-refs.py
@@ -113,12 +113,28 @@ def image_tag_sort(value):
         # 0.6-622d10efb15c602b5e47d8fd98e374bb2c45c149
         name_parts = name_parts[:-1]
 
+    # Version tags contain a varying number of parts. Some examples:
+    #   - 0.3.2-0
+    #   - 0.3
+    #   - 0.12.0
+    #   - 0.11.2-0
+    #
+    # Sort using a two item sequence.
+    #
+    # The first item is a tuple of integers padded with zeros to always be
+    # four items long, such as (0, 3, 2, 0). The padding is necessary because
+    # a shorter sequence would stop the comparison process and ignore the
+    # timestamp value.
+    #
+    # The second item is the epoch timestamp.
+    timestamp = value.get("start_ts", 0)
+    number_parts = 4
+    pad: tuple[int, ...] = (0,) * number_parts
     try:
-        version = [int(n) for n in name_parts]
-        version.append(value.get("start_ts", 0))
-        return tuple(version)
+        padded_version = tuple([int(n) for n in name_parts] + [*pad])[:number_parts]
+        return (padded_version, timestamp)
     except ValueError:
-        return (0, 0, value.get("start_ts", 0))
+        return (pad, timestamp)
 
 
 def filter_tags(

--- a/scripts/update-konflux-refs.py
+++ b/scripts/update-konflux-refs.py
@@ -93,7 +93,9 @@ def parse_args():
     parser.add_argument("--file", "-f", required=False, type=Path)
     parser.add_argument("--image", "-i", required=False, help="Print out list of tags for a given image")
     parser.add_argument("--overwrite", "-o", action="store_true")
-    parser.add_argument("--tag-length", "-l", default=4, type=int, help="Tags greater than this length will be omitted")
+    parser.add_argument(
+        "--tag-length", "-l", default=11, type=int, help="Tags greater than this length will be omitted"
+    )
     parser.add_argument("--max-count", "-m", help="Maximum number of image tags to gather", type=int, default=50)
     parser.add_argument("--workers", "-t", help="Number of concurrent workers", type="positive integer", default=16)
 

--- a/scripts/update-konflux-refs.py
+++ b/scripts/update-konflux-refs.py
@@ -105,7 +105,7 @@ def parse_args():
     return parser.parse_args()
 
 
-def image_tag_sort(value):
+def image_tag_sort(value) -> tuple[int, ...]:
     """Sort based on the version number in the tag and the creation date."""
 
     name = value.get("name", "").replace("-", ".")
@@ -121,22 +121,19 @@ def image_tag_sort(value):
     #   - 0.12.0
     #   - 0.11.2-0
     #
-    # Sort using a two item sequence.
+    # Sort using a fixed length sequence.
     #
-    # The first item is a tuple of integers padded with zeros to always be
-    # four items long, such as (0, 3, 2, 0). The padding is necessary because
-    # a shorter sequence would stop the comparison process and ignore the
-    # timestamp value.
-    #
-    # The second item is the epoch timestamp.
+    # Pad the version sequence with zeros to always be four items long,
+    # such as (0, 3, 2, 0). The padding is necessary so that all values in
+    # each sequence are compared.
     timestamp = value.get("start_ts", 0)
     number_parts = 4
-    pad: tuple[int, ...] = (0,) * number_parts
+    pad = [0] * number_parts
     try:
-        padded_version = tuple([int(n) for n in name_parts] + [*pad])[:number_parts]
-        return (padded_version, timestamp)
+        padded_version = ([int(n) for n in name_parts] + pad)[:number_parts]
+        return tuple(padded_version + [timestamp])
     except ValueError:
-        return (pad, timestamp)
+        return tuple(pad + [timestamp])
 
 
 def filter_tags(


### PR DESCRIPTION
With the introduction of version numbers consisting of more than two parts, the current sorting is incorrect. The sequence with the fewest items is ordered first.

For example, two version stings 0.3 (timestamp 1,000) and 0.3.2-0 (timestamp 1,001) have different lengths and the shortest would be sorted first even though version 0.3.2-0 has a newer timestamp.

`(0, 3, 1_000) < (0, 3, 2, 0, 1_0001) —> True`(not what we want)

Comparing the version parts as a fixed length sequence padded with zeros makes the sorting behave as intended.

`(0, 3, 0, 0, 1_000) < (0, 3, 2, 0, 1_0001) —> False`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image tag sorting for versioned and timestamped tags.
  - Supports longer image tags, allowing more complete version identifiers.
  - Provides consistent ordering for tags with varying numbers of version components.
  - Handles nonnumeric tags more reliably during reference updates.
  - Improves the reliability of image reference updates when tags use different version formats or include timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->