### PR TITLE
Urllib with async

### DIFF
--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -82,7 +82,7 @@ async def query_rbac(
     logger.debug(
         "RBAC request: url=%s identity_present=%s identity_type=%s",
         url,
-        "X-RH-Identity" in headers,
+        x_rh_identity is not None,
         type(x_rh_identity).__name__,
     )
 

--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -10,7 +10,6 @@ import urllib.request
 from collections.abc import AsyncGenerator
 from datetime import date
 from urllib.error import HTTPError
-from urllib.error import URLError
 from uuid import UUID
 
 from fastapi import Depends
@@ -52,11 +51,6 @@ async def decode_header(
     return org_id
 
 
-class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
-    def redirect_request(self, req, fp, code, msg, headers, newurl) -> t.NoReturn:
-        raise HTTPError(req.full_url, code, "RBAC redirect blocked", headers, fp)
-
-
 async def query_rbac(
     settings: t.Annotated[Settings, Depends(Settings.create)],
     x_rh_identity: t.Annotated[str | None, Header(include_in_schema=False)] = None,
@@ -79,33 +73,17 @@ async def query_rbac(
         return [{}]
 
     url = f"{settings.rbac_url}/api/rbac/v1/access/?{urllib.parse.urlencode(params, doseq=True)}"
-    logger.debug(
-        "RBAC request: url=%s identity_present=%s identity_type=%s",
-        url,
-        x_rh_identity is not None,
-        type(x_rh_identity).__name__,
-    )
 
     def _fetch_rbac():
-        opener = urllib.request.build_opener(_NoRedirectHandler)
         req = urllib.request.Request(url, headers=headers)
-        with opener.open(req, timeout=30) as response:
+        with urllib.request.urlopen(req, timeout=30) as response:
             return json.load(response)
 
     try:
         data = await asyncio.to_thread(_fetch_rbac)
     except HTTPError as err:
-        logger.error("Problem querying RBAC: status=%s url=%s %s", err.code, url, err)
+        logger.error(f"Problem querying RBAC: {err}")
         raise HTTPException(status_code=err.code, detail=err.msg)
-    except URLError as err:
-        if isinstance(err.reason, TimeoutError):
-            logger.error("Timeout querying RBAC: %s", err)
-            raise HTTPException(status_code=504, detail="RBAC service timed out")
-        logger.error(f"Unexpected error querying RBAC: {err}", exc_info=True)
-        raise HTTPException(status_code=502, detail="Error communicating with RBAC service")
-    except TimeoutError as err:
-        logger.error("Timeout querying RBAC: %s", err)
-        raise HTTPException(status_code=504, detail="RBAC service timed out")
     except json.JSONDecodeError as err:
         logger.error(f"Invalid JSON response from RBAC: {err}")
         raise HTTPException(status_code=502, detail="Invalid JSON response from RBAC service")

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -155,26 +155,25 @@ async def test_decode_header(value, expected):
 async def test_query_rbac(mocker, read_fixture_file):
     settings = Settings(rbac_hostname="example.com")
     fixture_data = json.loads(read_fixture_file("rbac_response.json", mode="rb"))
-    mock_response = MagicMock()
-    mock_response.__enter__ = MagicMock(
-        return_value=MagicMock(read=MagicMock(return_value=json.dumps(fixture_data).encode()))
+    mocker.patch(
+        "roadmap.common.urllib.request.urlopen",
+        return_value=MagicMock(
+            __enter__=MagicMock(return_value=MagicMock(read=MagicMock(return_value=json.dumps(fixture_data).encode()))),
+            __exit__=MagicMock(return_value=False),
+        ),
     )
-    mock_response.__exit__ = MagicMock(return_value=False)
-    mock_opener = MagicMock()
-    mock_opener.open.return_value = mock_response
-    mocker.patch("roadmap.common.urllib.request.build_opener", return_value=mock_opener)
 
     result = await query_rbac(settings)
 
     assert result == [{"permission": "inventory:*:*:foo", "resourceDefinitions": []}]
-    assert mock_opener.open.call_args.kwargs["timeout"] == 30
 
 
 async def test_query_rbac_error(mocker):
     settings = Settings(rbac_hostname="example.com")
-    mock_opener = MagicMock()
-    mock_opener.open.side_effect = HTTPError("http://example.com", 401, "Unauthorized", {}, None)
-    mocker.patch("roadmap.common.urllib.request.build_opener", return_value=mock_opener)
+    mocker.patch(
+        "roadmap.common.urllib.request.urlopen",
+        side_effect=HTTPError("http://example.com", 401, "Unauthorized", {}, None),
+    )
 
     with pytest.raises(HTTPException) as exc_info:
         await query_rbac(settings)
@@ -201,76 +200,24 @@ async def test_query_rbac_no_url():
 
 async def test_query_rbac_json_decode_error(mocker):
     settings = Settings(rbac_hostname="example.com")
-    mock_response = MagicMock()
-    mock_response.__enter__ = MagicMock(return_value=MagicMock(read=MagicMock(return_value=b"not json")))
-    mock_response.__exit__ = MagicMock(return_value=False)
-    mock_opener = MagicMock()
-    mock_opener.open.return_value = mock_response
-    mocker.patch("roadmap.common.urllib.request.build_opener", return_value=mock_opener)
+    mocker.patch(
+        "roadmap.common.urllib.request.urlopen",
+        return_value=MagicMock(
+            __enter__=MagicMock(return_value=MagicMock(read=MagicMock(return_value=b"not json"))),
+            __exit__=MagicMock(return_value=False),
+        ),
+    )
 
     with pytest.raises(HTTPException, match="Invalid JSON response from RBAC service"):
         await query_rbac(settings)
 
 
-def test_query_rbac_redirect_blocked():
-    from roadmap.common import _NoRedirectHandler
-
-    handler = _NoRedirectHandler()
-    req = MagicMock()
-    req.full_url = "http://rbac-service.svc:8000/api/rbac/v1/access/"
-
-    with pytest.raises(HTTPError) as exc_info:
-        handler.redirect_request(req, None, 302, "Found", {}, "http://evil.com/steal")
-
-    assert exc_info.value.code == 302
-    assert exc_info.value.msg == "RBAC redirect blocked"
-
-
-async def test_query_rbac_socket_timeout(mocker):
-    from urllib.error import URLError
-
-    settings = Settings(rbac_hostname="example.com")
-    mock_opener = MagicMock()
-    mock_opener.open.side_effect = URLError(TimeoutError("timed out"))
-    mocker.patch("roadmap.common.urllib.request.build_opener", return_value=mock_opener)
-
-    with pytest.raises(HTTPException, match="RBAC service timed out") as exc_info:
-        await query_rbac(settings)
-
-    assert exc_info.value.status_code == 504
-
-
-async def test_query_rbac_direct_timeout(mocker):
-    settings = Settings(rbac_hostname="example.com")
-    mock_opener = MagicMock()
-    mock_opener.open.side_effect = TimeoutError("read timed out")
-    mocker.patch("roadmap.common.urllib.request.build_opener", return_value=mock_opener)
-
-    with pytest.raises(HTTPException, match="RBAC service timed out") as exc_info:
-        await query_rbac(settings)
-
-    assert exc_info.value.status_code == 504
-
-
-async def test_query_rbac_url_error(mocker):
-    from urllib.error import URLError
-
-    settings = Settings(rbac_hostname="example.com")
-    mock_opener = MagicMock()
-    mock_opener.open.side_effect = URLError("Name or service not known")
-    mocker.patch("roadmap.common.urllib.request.build_opener", return_value=mock_opener)
-
-    with pytest.raises(HTTPException, match="Error communicating with RBAC service") as exc_info:
-        await query_rbac(settings)
-
-    assert exc_info.value.status_code == 502
-
-
 async def test_query_rbac_generic_exception(mocker):
     settings = Settings(rbac_hostname="example.com")
-    mock_opener = MagicMock()
-    mock_opener.open.side_effect = Exception("Connection timeout")
-    mocker.patch("roadmap.common.urllib.request.build_opener", return_value=mock_opener)
+    mocker.patch(
+        "roadmap.common.urllib.request.urlopen",
+        side_effect=Exception("Connection timeout"),
+    )
 
     with pytest.raises(HTTPException, match="Error communicating with RBAC service"):
         await query_rbac(settings)

--- a/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
@@ -59,11 +59,10 @@ def test_get_relevant_app_stream_error(api_prefix, client, mocker):
     def settings_override():
         return Settings(rbac_hostname="example.com")
 
-    from unittest.mock import MagicMock
-
-    mock_opener = MagicMock()
-    mock_opener.open.side_effect = HTTPError("http://example.com", 400, "Bad Request", {}, None)
-    mocker.patch("roadmap.common.urllib.request.build_opener", return_value=mock_opener)
+    mocker.patch(
+        "roadmap.common.urllib.request.urlopen",
+        side_effect=HTTPError("http://example.com", 400, "Bad Request", {}, None),
+    )
 
     client.app.dependency_overrides = {}
     client.app.dependency_overrides[Settings.create] = settings_override


### PR DESCRIPTION
- Revert query_rbac() from build_opener(_NoRedirectHandler) back to urllib.request.urlopen, matching the pre-#397 working code while keeping asyncio.to_thread to avoid blocking the event loop
- Remove _NoRedirectHandler class, URLError/TimeoutError exception handlers, and debug logging added in #402/#404
- Update all RBAC tests to mock urlopen instead of build_opener

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RBAC request handling by using standard HTTP request behavior.
  * Preserved status-based handling for HTTP errors and clearer error reporting.
  * Updated related application stream error handling for consistency.

* **Tests**
  * Updated coverage for HTTP responses, errors, JSON decoding, and communication failures.
  * Removed obsolete redirect, timeout, and URL-error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->