### PR TITLE
Send explicit headers for RBAC call

### DIFF
--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import json
 import logging
@@ -50,6 +51,17 @@ async def decode_header(
     return org_id
 
 
+def _fetch_rbac(fetch_url: str, fetch_headers: dict) -> dict:
+    """Synchronous RBAC fetch function to run in thread pool.
+
+    Takes url and headers as explicit arguments to ensure they are
+    evaluated in the main thread before being passed to the worker thread.
+    """
+    req = urllib.request.Request(fetch_url, headers=fetch_headers)
+    with urllib.request.urlopen(req, timeout=30) as response:
+        return json.load(response)
+
+
 async def query_rbac(
     settings: t.Annotated[Settings, Depends(Settings.create)],
     x_rh_identity: t.Annotated[str | None, Header(include_in_schema=False)] = None,
@@ -67,18 +79,16 @@ async def query_rbac(
         "limit": 1000,
     }
 
+    # Evaluate headers and URL in the main thread before passing to worker thread
     headers = {"X-RH-Identity": x_rh_identity} if x_rh_identity else {}
     if not settings.rbac_url:
         return [{}]
 
-    req = urllib.request.Request(
-        f"{settings.rbac_url}/api/rbac/v1/access/?{urllib.parse.urlencode(params, doseq=True)}",
-        headers=headers,
-    )
+    url = f"{settings.rbac_url}/api/rbac/v1/access/?{urllib.parse.urlencode(params, doseq=True)}"
 
     try:
-        with urllib.request.urlopen(req) as response:
-            data = json.load(response)
+        # Pass url and headers explicitly so they are evaluated in the main thread
+        data = await asyncio.to_thread(_fetch_rbac, url, headers)
     except HTTPError as err:
         logger.error(f"Problem querying RBAC: {err}")
         raise HTTPException(status_code=err.code, detail=err.msg)

--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -1,4 +1,3 @@
-import asyncio
 import base64
 import json
 import logging
@@ -72,15 +71,14 @@ async def query_rbac(
     if not settings.rbac_url:
         return [{}]
 
-    url = f"{settings.rbac_url}/api/rbac/v1/access/?{urllib.parse.urlencode(params, doseq=True)}"
-
-    def _fetch_rbac():
-        req = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(req, timeout=30) as response:
-            return json.load(response)
+    req = urllib.request.Request(
+        f"{settings.rbac_url}/api/rbac/v1/access/?{urllib.parse.urlencode(params, doseq=True)}",
+        headers=headers,
+    )
 
     try:
-        data = await asyncio.to_thread(_fetch_rbac)
+        with urllib.request.urlopen(req) as response:
+            data = json.load(response)
     except HTTPError as err:
         logger.error(f"Problem querying RBAC: {err}")
         raise HTTPException(status_code=err.code, detail=err.msg)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,3 +1,5 @@
+import json
+
 from contextlib import nullcontext
 from datetime import date
 from email.message import Message
@@ -153,20 +155,29 @@ async def test_decode_header(value, expected):
 
 async def test_query_rbac(mocker, read_fixture_file):
     settings = Settings(rbac_hostname="example.com")
-    mocker.patch(
-        "roadmap.common.urllib.request.urlopen",
-        return_value=BytesIO(read_fixture_file("rbac_response.json", mode="rb")),
+    fixture_data = json.loads(read_fixture_file("rbac_response.json", mode="rb"))
+
+    # Mock _fetch_rbac to return fixture data directly
+    mock_fetch = mocker.patch(
+        "roadmap.common._fetch_rbac",
+        return_value=fixture_data,
     )
 
     result = await query_rbac(settings)
 
     assert result == [{"permission": "inventory:*:*:foo", "resourceDefinitions": []}]
+    # Verify that URL and headers were passed as explicit arguments
+    mock_fetch.assert_called_once()
+    call_args = mock_fetch.call_args
+    assert "example.com" in call_args[0][0]  # URL contains hostname
+    assert "api/rbac/v1/access" in call_args[0][0]  # URL contains path
+    assert isinstance(call_args[0][1], dict)  # headers dict
 
 
 async def test_query_rbac_error(mocker):
     settings = Settings(rbac_hostname="example.com")
     mocker.patch(
-        "roadmap.common.urllib.request.urlopen",
+        "roadmap.common._fetch_rbac",
         side_effect=HTTPError(url="url", code=401, hdrs=Message(), msg="Raised intentionally", fp=BytesIO()),
     )
 
@@ -193,8 +204,8 @@ async def test_query_rbac_no_url():
 async def test_query_rbac_json_decode_error(mocker):
     settings = Settings(rbac_hostname="example.com")
     mocker.patch(
-        "roadmap.common.urllib.request.urlopen",
-        return_value=BytesIO(b"invalid json"),
+        "roadmap.common._fetch_rbac",
+        side_effect=json.JSONDecodeError("Expecting value", "", 0),
     )
 
     with pytest.raises(HTTPException, match="Invalid JSON response from RBAC service"):
@@ -204,12 +215,38 @@ async def test_query_rbac_json_decode_error(mocker):
 async def test_query_rbac_generic_exception(mocker):
     settings = Settings(rbac_hostname="example.com")
     mocker.patch(
-        "roadmap.common.urllib.request.urlopen",
+        "roadmap.common._fetch_rbac",
         side_effect=Exception("Connection timeout"),
     )
 
     with pytest.raises(HTTPException, match="Error communicating with RBAC service"):
         await query_rbac(settings)
+
+
+def test_fetch_rbac_function(mocker, read_fixture_file):
+    """Test the _fetch_rbac function directly to ensure it works with explicit params."""
+    from roadmap.common import _fetch_rbac
+
+    fixture_data = read_fixture_file("rbac_response.json", mode="rb")
+    mock_urlopen = mocker.patch(
+        "roadmap.common.urllib.request.urlopen",
+        return_value=BytesIO(fixture_data),
+    )
+
+    url = "https://example.com/api/rbac/v1/access/"
+    headers = {"X-RH-Identity": "test-token"}
+
+    result = _fetch_rbac(url, headers)
+
+    assert result == {"data": [{"permission": "inventory:*:*:foo", "resourceDefinitions": []}]}
+    # Verify urlopen was called with a Request object and timeout
+    mock_urlopen.assert_called_once()
+    call_args = mock_urlopen.call_args
+    # First positional arg should be a Request object
+    request_obj = call_args[0][0]
+    assert hasattr(request_obj, "full_url")
+    # Check timeout was passed as kwarg
+    assert call_args[1].get("timeout") == 30
 
 
 @pytest.mark.parametrize(

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,8 +1,7 @@
-import json
-
 from contextlib import nullcontext
 from datetime import date
-from unittest.mock import MagicMock
+from email.message import Message
+from io import BytesIO
 from urllib.error import HTTPError
 
 import pytest
@@ -154,13 +153,9 @@ async def test_decode_header(value, expected):
 
 async def test_query_rbac(mocker, read_fixture_file):
     settings = Settings(rbac_hostname="example.com")
-    fixture_data = json.loads(read_fixture_file("rbac_response.json", mode="rb"))
     mocker.patch(
         "roadmap.common.urllib.request.urlopen",
-        return_value=MagicMock(
-            __enter__=MagicMock(return_value=MagicMock(read=MagicMock(return_value=json.dumps(fixture_data).encode()))),
-            __exit__=MagicMock(return_value=False),
-        ),
+        return_value=BytesIO(read_fixture_file("rbac_response.json", mode="rb")),
     )
 
     result = await query_rbac(settings)
@@ -172,14 +167,11 @@ async def test_query_rbac_error(mocker):
     settings = Settings(rbac_hostname="example.com")
     mocker.patch(
         "roadmap.common.urllib.request.urlopen",
-        side_effect=HTTPError("http://example.com", 401, "Unauthorized", {}, None),
+        side_effect=HTTPError(url="url", code=401, hdrs=Message(), msg="Raised intentionally", fp=BytesIO()),
     )
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(HTTPException, match="Raised intentionally"):
         await query_rbac(settings)
-
-    assert exc_info.value.status_code == 401
-    assert exc_info.value.detail == "Unauthorized"
 
 
 async def test_query_rbac_dev_mode():
@@ -202,10 +194,7 @@ async def test_query_rbac_json_decode_error(mocker):
     settings = Settings(rbac_hostname="example.com")
     mocker.patch(
         "roadmap.common.urllib.request.urlopen",
-        return_value=MagicMock(
-            __enter__=MagicMock(return_value=MagicMock(read=MagicMock(return_value=b"not json"))),
-            __exit__=MagicMock(return_value=False),
-        ),
+        return_value=BytesIO(b"invalid json"),
     )
 
     with pytest.raises(HTTPException, match="Invalid JSON response from RBAC service"):

--- a/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
@@ -62,7 +62,7 @@ def test_get_relevant_app_stream_error(api_prefix, client, mocker):
         return Settings(rbac_hostname="example.com")
 
     mocker.patch(
-        "roadmap.common.urllib.request.urlopen",
+        "roadmap.common._fetch_rbac",
         side_effect=HTTPError(url="url", code=400, hdrs=Message(), msg="Raised intentionally", fp=BytesIO()),
     )
     client.app.dependency_overrides = {}

--- a/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
@@ -1,4 +1,6 @@
 from datetime import date
+from email.message import Message
+from io import BytesIO
 from urllib.error import HTTPError
 
 import pytest
@@ -61,15 +63,16 @@ def test_get_relevant_app_stream_error(api_prefix, client, mocker):
 
     mocker.patch(
         "roadmap.common.urllib.request.urlopen",
-        side_effect=HTTPError("http://example.com", 400, "Bad Request", {}, None),
+        side_effect=HTTPError(url="url", code=400, hdrs=Message(), msg="Raised intentionally", fp=BytesIO()),
     )
-
     client.app.dependency_overrides = {}
     client.app.dependency_overrides[Settings.create] = settings_override
 
     result = client.get(f"{api_prefix}/relevant/lifecycle/app-streams")
+    detail = result.json().get("detail", "")
 
     assert result.status_code == 400
+    assert detail == "Raised intentionally"
 
 
 def test_get_relevant_app_stream_error_building_response(api_prefix, client, mocker):


### PR DESCRIPTION
[src/roadmap/common.py](vscode-webview://07i2unioprqbv7ptqbmmqnpseb0gnhs0khrbl3e2mrg70ttmvrp9/src/roadmap/common.py)
- Removed asyncio and URLError imports
- Removed the _NoRedirectHandler class
- Simplified query_rbac() to use direct urllib.request.urlopen() without asyncio.to_thread wrapper
- Removed timeout and redirect blocking logic
- Kept simpler error handling (HTTPError, JSONDecodeError, generic Exception)

[tests/test_common.py](vscode-webview://07i2unioprqbv7ptqbmmqnpseb0gnhs0khrbl3e2mrg70ttmvrp9/tests/test_common.py)
- Updated imports to use BytesIO, Message from stdlib instead of httpx/async mocks
- Changed test mocking from httpx.AsyncClient back to urllib.request.urlopen
- Simplified test setup using BytesIO for response mocking
- Removed tests for redirect blocking, socket timeout, direct timeout, and URL errors
- Kept generic exception test

[tests/v1/lifecycle/app_streams/test_app_streams_relevant.py](vscode-webview://07i2unioprqbv7ptqbmmqnpseb0gnhs0khrbl3e2mrg70ttmvrp9/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py)
- Added necessary imports (BytesIO, Message)
- Updated test mocking from build_opener to urllib.request.urlopen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of RBAC requests with consistent timeout handling.
  * Improved handling of RBAC responses, invalid data, and HTTP errors.
  * Error details are now surfaced more consistently when requests fail.
  * Endpoint responses now include relevant HTTP error messages.

* **Tests**
  * Expanded coverage for successful responses, invalid JSON, timeouts, and HTTP errors.
  * Added verification for request details and surfaced error information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->