### PR TITLE
Add diagnostic logging to RBAC request to debug 400 errors

### DIFF
--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -57,6 +57,12 @@ def _fetch_rbac(fetch_url: str, fetch_headers: dict) -> dict:
     Takes url and headers as explicit arguments to ensure they are
     evaluated in the main thread before being passed to the worker thread.
     """
+    logger.info(f"RBAC request - URL: {fetch_url}")
+    logger.info(f"RBAC request - Headers keys: {list(fetch_headers.keys())}")
+    logger.info(f"RBAC request - Has X-RH-Identity: {bool(fetch_headers.get('X-RH-Identity'))}")
+    if fetch_headers.get("X-RH-Identity"):
+        logger.info(f"RBAC request - X-RH-Identity length: {len(fetch_headers.get('X-RH-Identity', ''))}")
+
     req = urllib.request.Request(fetch_url, headers=fetch_headers)
     with urllib.request.urlopen(req, timeout=30) as response:
         return json.load(response)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -232,6 +232,7 @@ def test_fetch_rbac_function(mocker, read_fixture_file):
         "roadmap.common.urllib.request.urlopen",
         return_value=BytesIO(fixture_data),
     )
+    mock_logger = mocker.patch("roadmap.common.logger")
 
     url = "https://example.com/api/rbac/v1/access/"
     headers = {"X-RH-Identity": "test-token"}
@@ -247,6 +248,29 @@ def test_fetch_rbac_function(mocker, read_fixture_file):
     assert hasattr(request_obj, "full_url")
     # Check timeout was passed as kwarg
     assert call_args[1].get("timeout") == 30
+    # Verify logging calls were made
+    assert mock_logger.info.call_count == 4  # 4 logging statements when X-RH-Identity is present
+
+
+def test_fetch_rbac_function_no_identity_header(mocker, read_fixture_file):
+    """Test the _fetch_rbac function without X-RH-Identity header."""
+    from roadmap.common import _fetch_rbac
+
+    fixture_data = read_fixture_file("rbac_response.json", mode="rb")
+    mocker.patch(
+        "roadmap.common.urllib.request.urlopen",
+        return_value=BytesIO(fixture_data),
+    )
+    mock_logger = mocker.patch("roadmap.common.logger")
+
+    url = "https://example.com/api/rbac/v1/access/"
+    headers = {}
+
+    result = _fetch_rbac(url, headers)
+
+    assert result == {"data": [{"permission": "inventory:*:*:foo", "resourceDefinitions": []}]}
+    # Verify logging calls were made (3 logs when no X-RH-Identity)
+    assert mock_logger.info.call_count == 3
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Log URL, headers, and X-RH-Identity presence/length when making RBAC calls to help identify why stage is returning 400 Bad Request errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added diagnostic logging for RBAC requests, including request details and identity-header availability.
  * Improved visibility into request identity information without changing public functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->