### PR TITLE
Switch to the async kessel SDK

### DIFF
--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -193,9 +193,9 @@ async def _allowed_host_groups_kessel(
 
     identity = _decode_identity(x_rh_identity)
     subject = kessel.subject_from_identity(identity, settings.kessel_principal_domain)
-    client = kessel.get_client(settings)
 
     try:
+        client = kessel.get_client(settings)
         workspace_ids = set(await kessel.host_groups_for(client, subject))
     except HTTPException:
         raise

--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -196,7 +196,7 @@ async def _allowed_host_groups_kessel(
     client = kessel.get_client(settings)
 
     try:
-        workspace_ids = set(kessel.host_groups_for(client, subject))
+        workspace_ids = set(await kessel.host_groups_for(client, subject))
     except HTTPException:
         raise
     except Exception as err:

--- a/src/roadmap/kessel.py
+++ b/src/roadmap/kessel.py
@@ -28,7 +28,7 @@ from fastapi import HTTPException
 from kessel.auth import fetch_oidc_discovery
 from kessel.auth import OAuth2ClientCredentials
 from kessel.inventory.v1beta2 import ClientBuilder
-from kessel.rbac.v2 import list_workspaces
+from kessel.rbac.v2 import list_workspaces_async
 from kessel.rbac.v2 import principal_subject
 
 from roadmap.config import Settings
@@ -67,7 +67,7 @@ def _build_credentials(settings: Settings) -> OAuth2ClientCredentials:
 
 
 def get_client(settings: Settings) -> t.Any:
-    """Return a cached Kessel Inventory gRPC stub, building it on first use."""
+    """Return a cached async Kessel Inventory gRPC stub, building it on first use."""
     global _client
     if _client is not None:
         return _client
@@ -80,10 +80,12 @@ def get_client(settings: Settings) -> t.Any:
     else:
         builder.unauthenticated()
 
-    # build() returns (stub, channel); we only need the stub.
-    _client, _ = builder.build()
-    # Do not log settings.kessel_url; it may reveal an internal hostname/IP.
-    logger.info("Built Kessel client")
+    # build_async() returns an async stub that uses grpc.aio channels, which
+    # integrate with the asyncio event loop. The sync build() sets
+    # SingleThreadedUnaryStream which deadlocks when the calling thread is
+    # the asyncio event loop (FastAPI runs async handlers on the loop).
+    _client, _ = builder.build_async()
+    logger.info("Built Kessel client (async)")
     return _client
 
 
@@ -102,13 +104,11 @@ def subject_from_identity(identity: dict[str, t.Any], domain: str) -> t.Any:
     return principal_subject(str(user_id), domain)
 
 
-def host_groups_for(client: t.Any, subject: t.Any) -> list[str]:
+async def host_groups_for(client: t.Any, subject: t.Any) -> list[str]:
     """Return the workspace ids the subject may view hosts in.
 
     Enumerates workspaces via the Kessel Inventory ``StreamedListObjects`` API
     (pagination handled by the SDK) using the ``inventory_host_view`` relation.
     """
-    # We always consume the whole result, so materialise it eagerly via list()
-    # per the kessel-sdk list_workspaces guidance, then project each response.
-    responses = list(list_workspaces(client, subject, HOST_VIEW_RELATION))
+    responses = [r async for r in list_workspaces_async(client, subject, HOST_VIEW_RELATION)]
     return [response.object.resource_id for response in responses]

--- a/tests/test_kessel.py
+++ b/tests/test_kessel.py
@@ -37,19 +37,24 @@ def test_subject_from_identity_no_user_id(identity):
         kessel.subject_from_identity(identity, "redhat")
 
 
-def test_host_groups_for(mocker):
+@pytest.mark.asyncio
+async def test_host_groups_for(mocker):
     responses = [
         mocker.Mock(object=mocker.Mock(resource_id="grp-1")),
         mocker.Mock(object=mocker.Mock(resource_id="grp-2")),
     ]
-    list_workspaces = mocker.patch("roadmap.kessel.list_workspaces", return_value=responses)
+
+    async def _fake_list(*args, **kwargs):
+        for r in responses:
+            yield r
+
+    mocker.patch("roadmap.kessel.list_workspaces_async", side_effect=_fake_list)
     client = mocker.Mock()
     subject = mocker.Mock()
 
-    result = kessel.host_groups_for(client, subject)
+    result = await kessel.host_groups_for(client, subject)
 
     assert result == ["grp-1", "grp-2"]
-    list_workspaces.assert_called_once_with(client, subject, kessel.HOST_VIEW_RELATION)
 
 
 def test_get_client_insecure(mocker):
@@ -59,7 +64,7 @@ def test_get_client_insecure(mocker):
     settings = Settings(kessel_url="localhost:9000", kessel_insecure=True)
     builder = mocker.Mock()
     stub = mocker.Mock()
-    builder.build.return_value = (stub, mocker.Mock())
+    builder.build_async.return_value = (stub, mocker.Mock())
     client_builder = mocker.patch("roadmap.kessel.ClientBuilder", return_value=builder)
 
     result = kessel.get_client(settings)
@@ -72,7 +77,7 @@ def test_get_client_insecure(mocker):
 
     # Second call is served from the cached client.
     assert kessel.get_client(settings) is stub
-    builder.build.assert_called_once()
+    builder.build_async.assert_called_once()
 
     kessel.reset_caches()
 
@@ -84,7 +89,7 @@ def test_get_client_authenticated(mocker):
     settings = Settings(kessel_url="kessel:443", kessel_insecure=False, kessel_auth_enabled=True)
     builder = mocker.Mock()
     stub = mocker.Mock()
-    builder.build.return_value = (stub, mocker.Mock())
+    builder.build_async.return_value = (stub, mocker.Mock())
     mocker.patch("roadmap.kessel.ClientBuilder", return_value=builder)
     creds = mocker.Mock()
     build_creds = mocker.patch("roadmap.kessel._build_credentials", return_value=creds)
@@ -106,7 +111,7 @@ def test_get_client_unauthenticated(mocker):
     settings = Settings(kessel_url="kessel:443", kessel_insecure=False, kessel_auth_enabled=False)
     builder = mocker.Mock()
     stub = mocker.Mock()
-    builder.build.return_value = (stub, mocker.Mock())
+    builder.build_async.return_value = (stub, mocker.Mock())
     mocker.patch("roadmap.kessel.ClientBuilder", return_value=builder)
 
     result = kessel.get_client(settings)


### PR DESCRIPTION
We were using builder.build() (sync gRPC channel with SingleThreadedUnaryStream option) from inside an async def FastAPI route handler. The SingleThreadedUnaryStream option drives server-streaming response polling on the calling thread, which in our case is the asyncio event loop. This creates a conflict: gRPC's internal polling competes with asyncio for the thread, causing the HTTP/2 connection handshake to stall and eventually time out with tcp handshaker shutdown after ~20 seconds.

This PR switches to the async SDK path. This is the correct approach for FastAPI and eliminates the SingleThreadedUnaryStream + event-loop conflict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kessel host-group lookups by correctly handling asynchronous authorization and workspace retrieval.
  * Preserved existing error handling and workspace authorization behavior.
* **Tests**
  * Updated coverage to validate asynchronous client setup, workspace listing, and host-group lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->