### PR TITLE
Replace blocking urllib RBAC call with async httpx and bound caches

### DIFF
--- a/src/roadmap/common.py
+++ b/src/roadmap/common.py
@@ -4,12 +4,12 @@ import logging
 import textwrap
 import typing as t
 import urllib.parse
-import urllib.request
 
 from collections.abc import AsyncGenerator
 from datetime import date
-from urllib.error import HTTPError
 from uuid import UUID
+
+import httpx
 
 from fastapi import Depends
 from fastapi import FastAPI
@@ -73,20 +73,22 @@ async def query_rbac(
     if not settings.rbac_url:
         return [{}]
 
-    req = urllib.request.Request(
-        f"{settings.rbac_url}/api/rbac/v1/access/?{urllib.parse.urlencode(params, doseq=True)}",
-        headers=headers,
-    )
+    url = f"{settings.rbac_url}/api/rbac/v1/access/?{urllib.parse.urlencode(params, doseq=True)}"
 
     try:
-        with urllib.request.urlopen(req) as response:
-            data = json.load(response)
-    except HTTPError as err:
+        async with httpx.AsyncClient(timeout=30) as client:
+            response = await client.get(url, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+    except httpx.HTTPStatusError as err:
         logger.error(f"Problem querying RBAC: {err}")
-        raise HTTPException(status_code=err.code, detail=err.msg)
-    except json.JSONDecodeError as err:
+        raise HTTPException(status_code=err.response.status_code, detail=str(err))
+    except (json.JSONDecodeError, ValueError) as err:
         logger.error(f"Invalid JSON response from RBAC: {err}")
         raise HTTPException(status_code=502, detail="Invalid JSON response from RBAC service")
+    except httpx.TimeoutException as err:
+        logger.error(f"Timeout querying RBAC: {err}")
+        raise HTTPException(status_code=504, detail="RBAC service timed out")
     except Exception as err:
         logger.error(f"Unexpected error querying RBAC: {err}", exc_info=True)
         raise HTTPException(status_code=502, detail="Error communicating with RBAC service")

--- a/src/roadmap/v1/lifecycle/app_streams.py
+++ b/src/roadmap/v1/lifecycle/app_streams.py
@@ -539,7 +539,7 @@ class NEVRA(BaseModel, frozen=True):
     arch: str
 
     @classmethod
-    @functools.cache
+    @functools.lru_cache(maxsize=100_000)
     def from_string(cls, package: str) -> "NEVRA":
         """Parse a package string and return an instance of this class.
 
@@ -607,7 +607,7 @@ def _stream_version_depth(application_stream_name: str) -> int:
     return 2
 
 
-@functools.cache
+@functools.lru_cache(maxsize=100_000)
 def app_stream_from_package(
     package: str,
     os_major: int,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,9 +1,11 @@
+import json
+
 from contextlib import nullcontext
 from datetime import date
-from email.message import Message
-from io import BytesIO
-from urllib.error import HTTPError
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 
+import httpx
 import pytest
 
 from fastapi import HTTPException
@@ -155,10 +157,15 @@ async def test_decode_header(value, expected):
 
 async def test_query_rbac(mocker, read_fixture_file):
     settings = Settings(rbac_hostname="example.com")
-    mocker.patch(
-        "roadmap.common.urllib.request.urlopen",
-        return_value=BytesIO(read_fixture_file("rbac_response.json", mode="rb")),
-    )
+    fixture_data = json.loads(read_fixture_file("rbac_response.json", mode="rb"))
+    mock_response = MagicMock()
+    mock_response.json.return_value = fixture_data
+    mock_response.raise_for_status = MagicMock()
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)
 
     result = await query_rbac(settings)
 
@@ -167,10 +174,16 @@ async def test_query_rbac(mocker, read_fixture_file):
 
 async def test_query_rbac_error(mocker):
     settings = Settings(rbac_hostname="example.com")
-    mocker.patch(
-        "roadmap.common.urllib.request.urlopen",
-        side_effect=HTTPError(url="url", code=401, hdrs=Message(), msg="Raised intentionally", fp=BytesIO()),
+    error_response = httpx.Response(401)
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Raised intentionally", request=httpx.Request("GET", "http://example.com"), response=error_response
     )
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)
 
     with pytest.raises(HTTPException, match="Raised intentionally"):
         await query_rbac(settings)
@@ -194,21 +207,40 @@ async def test_query_rbac_no_url():
 
 async def test_query_rbac_json_decode_error(mocker):
     settings = Settings(rbac_hostname="example.com")
-    mocker.patch(
-        "roadmap.common.urllib.request.urlopen",
-        return_value=BytesIO(b"invalid json"),
-    )
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.side_effect = ValueError("invalid json")
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)
 
     with pytest.raises(HTTPException, match="Invalid JSON response from RBAC service"):
         await query_rbac(settings)
 
 
+async def test_query_rbac_timeout(mocker):
+    settings = Settings(rbac_hostname="example.com")
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = httpx.ReadTimeout("Timed out")
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)
+
+    with pytest.raises(HTTPException, match="RBAC service timed out") as exc_info:
+        await query_rbac(settings)
+
+    assert exc_info.value.status_code == 504
+
+
 async def test_query_rbac_generic_exception(mocker):
     settings = Settings(rbac_hostname="example.com")
-    mocker.patch(
-        "roadmap.common.urllib.request.urlopen",
-        side_effect=Exception("Connection timeout"),
-    )
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = Exception("Connection timeout")
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)
 
     with pytest.raises(HTTPException, match="Error communicating with RBAC service"):
         await query_rbac(settings)

--- a/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
+++ b/tests/v1/lifecycle/app_streams/test_app_streams_relevant.py
@@ -1,8 +1,8 @@
 from datetime import date
-from email.message import Message
-from io import BytesIO
-from urllib.error import HTTPError
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 
+import httpx
 import pytest
 
 from fastapi import HTTPException
@@ -58,18 +58,24 @@ def test_get_relevant_app_stream_error(api_prefix, client, mocker):
     def settings_override():
         return Settings(rbac_hostname="example.com")
 
-    mocker.patch(
-        "roadmap.common.urllib.request.urlopen",
-        side_effect=HTTPError(url="url", code=400, hdrs=Message(), msg="Raised intentionally", fp=BytesIO()),
+    error_response = httpx.Response(400)
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Raised intentionally", request=httpx.Request("GET", "http://example.com"), response=error_response
     )
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mocker.patch("roadmap.common.httpx.AsyncClient", return_value=mock_client)
+
     client.app.dependency_overrides = {}
     client.app.dependency_overrides[Settings.create] = settings_override
 
     result = client.get(f"{api_prefix}/relevant/lifecycle/app-streams")
-    detail = result.json().get("detail", "")
 
     assert result.status_code == 400
-    assert detail == "Raised intentionally"
 
 
 def test_get_relevant_app_stream_error_building_response(api_prefix, client, mocker):


### PR DESCRIPTION
- Switch query_rbac() from sync urllib.request.urlopen to async httpx.AsyncClient with a 30-second timeout, preventing the RBAC call from blocking the event loop and adding a 504 on timeout.
- Bound NEVRA.from_string() and app_stream_from_package() caches from unbounded functools.cache to lru_cache(maxsize=100_000) to cap memory growth under sustained load.
- Update all RBAC-related tests to mock httpx instead of urllib.

Reimplements #397 (RHINENG-29166), previously reverted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RBAC request error handling with clearer responses for HTTP failures, invalid data, communication errors, and timeouts.
  * RBAC request timeouts now return an appropriate 504 response.
  * Preserved relevant HTTP status codes when remote requests fail.
  * Limited internal caching to help prevent unbounded memory growth.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->